### PR TITLE
Aprimorado texto situação tributária para considerar também ICMSSN e ICMSOutraUF

### DIFF
--- a/src/CTe/DacteV3.php
+++ b/src/CTe/DacteV3.php
@@ -72,6 +72,8 @@ class DacteV3 extends Common
     protected $infNFe;
     protected $compl;
     protected $ICMS;
+    protected $ICMSSN;
+    protected $ICMSOutraUF;
     protected $imp;
     protected $toma4;
     protected $toma03;
@@ -190,6 +192,7 @@ class DacteV3 extends Common
             $this->compl = $this->dom->getElementsByTagName("compl");
             $this->ICMS = $this->dom->getElementsByTagName("ICMS")->item(0);
             $this->ICMSSN = $this->dom->getElementsByTagName("ICMSSN")->item(0);
+            $this->ICMSOutraUF = $this->dom->getElementsByTagName("ICMSOutraUF")->item(0);
             $this->imp = $this->dom->getElementsByTagName("imp")->item(0);
 
             $vTrib = $this->pSimpleGetValue($this->imp, "vTotTrib");
@@ -2036,7 +2039,7 @@ class DacteV3 extends Common
         $aFont = $this->formatPadrao;
         $this->pTextBox($x, $y, $w * 0.14, $h, $texto, $aFont, 'T', 'L', 0, '');
          * */
-        
+
         $x = $oldX;
         $y = $y + 4;
         $texto = $this->pSimpleGetValue($this->ICMS, "CST");
@@ -2060,11 +2063,15 @@ class DacteV3 extends Common
                 $texto = "60 - ICMS cobrado anteriormente por substituição tributária";
                 break;
             case '90':
-                $texto = "90 - ICMS outros";
+                if ($this->ICMSOutraUF) {
+                    $texto = "90 - ICMS Outra UF";
+                } elseif ($this->ICMSSN) {
+                    $texto = "90 - ICMS Simples Nacional";
+                } else {
+                    $texto = "90 - ICMS Outros";
+                }
                 break;
         }
-        $texto .= $this->pSimpleGetValue($this->ICMSSN, "indSN");
-        $texto = $texto == 1 ? 'Simples Nacional' : $texto;
         $aFont = $this->formatNegrito;
         $this->pTextBox($x, $y, $w * 0.26, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x += $w * 0.26;


### PR DESCRIPTION
[problema identificado]: 
 - Texto campo situação tributária com valor diferente do esperado #79 

[correções]
- adicionado a relação de propriedade da classe DACTeV3 a propriedade ICMSSN que estava sendo criada dinâmicamente.
- adicionado propriedade ICMSOutraUF como propriedade de classe de modo a receber valor da respectiva tag.
- no método zImpostos, removido trecho de código que estava concatenando valor 1 a string situação tributária.
- no método zImpostos, adicionado validação ao criar texto situação tributária para quando CST for 90, de modo a atribuir valor conforme orientações do manual do contribuinte.

