### PR TITLE
Melhorias na Dacte

### DIFF
--- a/src/CTe/DacteV3.php
+++ b/src/CTe/DacteV3.php
@@ -205,6 +205,10 @@ class DacteV3 extends Common
                     .$textoAdic;
             $this->toma4 = $this->dom->getElementsByTagName("toma4")->item(0);
             $this->toma03 = $this->dom->getElementsByTagName("toma3")->item(0);
+            //Tag tomador é identificado por toma03 na versão 2.00
+            if ($this->infCte->getAttribute("versao")=="2.00") {
+                $this->toma03 = $this->dom->getElementsByTagName("toma03")->item(0);
+            }
             //modal aquaviário
             $this->aquav = $this->dom->getElementsByTagName("aquav")->item(0);
             $tomador = $this->pSimpleGetValue($this->toma03, "toma");
@@ -1732,23 +1736,23 @@ class DacteV3 extends Common
         $y += 8;
         $x = $oldX;
         $this->pdf->Line($x, $y, $w + 1, $y);
+        
+        //Identifica código da unidade
+        //01 = KG (QUILOS)
+        if ($this->pSimpleGetValue($this->infQ->item(0), "cUnid") == '01') {
+            $qCarga = $this->pSimpleGetValue($this->infQ->item(0), "qCarga");
+        } elseif ($this->pSimpleGetValue($this->infQ->item(1), "cUnid") == '01') {
+            $qCarga = $this->pSimpleGetValue($this->infQ->item(1), "qCarga");
+        } elseif ($this->pSimpleGetValue($this->infQ->item(2), "cUnid") == '01') {
+            $qCarga = $this->pSimpleGetValue($this->infQ->item(2), "qCarga");
+        }
         $texto = 'PESO BRUTO (KG)';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 5,
             'style' => '');
         $this->pTextBox($x+8, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
-        //$texto = $this->pSimpleGetValue($this->infQ->item(0), "qCarga") . "\r\n";
-        $texto = number_format(
-            $this->pSimpleGetValue(
-                $this->infQ->item(0),
-                "qCarga"
-            ),
-            3,
-            ",",
-            "."
-        );
-        //$texto .= ' ' . $this->zUnidade($this->pSimpleGetValue($this->infQ->item(0), "cUnid"));
+        $texto = number_format($qCarga, 3, ",", ".");
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 7,
@@ -1756,21 +1760,14 @@ class DacteV3 extends Common
         $this->pTextBox($x+2, $y + 3, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x = $w * 0.12;
         $this->pdf->Line($x+13.5, $y, $x+13.5, $y + 9);
+        
         $texto = 'PESO BASE CÁLCULO (KG)';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 5,
             'style' => '');
         $this->pTextBox($x+20, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
-        $texto = number_format(
-            $this->pSimpleGetValue(
-                $this->infQ->item(0),
-                "qCarga"
-            ),
-            3,
-            ",",
-            "."
-        );
+        $texto = number_format($qCarga, 3, ",", ".");
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 7,
@@ -1778,21 +1775,14 @@ class DacteV3 extends Common
         $this->pTextBox($x+17, $y + 3, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x = $w * 0.24;
         $this->pdf->Line($x+25, $y, $x+25, $y + 9);
+        
         $texto = 'PESO AFERIDO (KG)';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 5,
             'style' => '');
         $this->pTextBox($x+35, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
-        $texto = number_format(
-            $this->pSimpleGetValue(
-                $this->infQ->item(0),
-                "qCarga"
-            ),
-            3,
-            ",",
-            "."
-        );
+        $texto = number_format($qCarga, 3, ",", ".");
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 7,
@@ -2039,7 +2029,7 @@ class DacteV3 extends Common
         $aFont = $this->formatPadrao;
         $this->pTextBox($x, $y, $w * 0.14, $h, $texto, $aFont, 'T', 'L', 0, '');
          * */
-
+        
         $x = $oldX;
         $y = $y + 4;
         $texto = $this->pSimpleGetValue($this->ICMS, "CST");
@@ -2274,44 +2264,44 @@ class DacteV3 extends Common
         switch ($qtdeNFe) {
             default:
                 $this->totPag = 1;
-            case ($qtdeNFe >= 1044):
+            case ($qtdeNFe >= 1134):
                 $this->totPag = 11;
                 break;
-            case ($qtdeNFe > 928):
+            case ($qtdeNFe > 1008):
                 $this->totPag = 10;
                 break;
-            case ($qtdeNFe > 812):
+            case ($qtdeNFe > 882):
                 $this->totPag = 9;
                 break;
-            case ($qtdeNFe > 696):
+            case ($qtdeNFe > 756):
                 $this->totPag = 8;
                 break;
-            case ($qtdeNFe > 580):
+            case ($qtdeNFe > 630):
                 $this->totPag = 7;
                 break;
-            case ($qtdeNFe > 464):
+            case ($qtdeNFe > 504):
                 $this->totPag = 6;
                 break;
-            case ($qtdeNFe > 348):
+            case ($qtdeNFe > 378):
                 $this->totPag = 5;
                 break;
-            case ($qtdeNFe > 232):
+            case ($qtdeNFe > 252):
                 $this->totPag = 4;
                 break;
-            case ($qtdeNFe > 116):
+            case ($qtdeNFe > 126):
                 $this->totPag = 3;
                 break;
-            case ($qtdeNFe > 16):
+            case ($qtdeNFe > 26):
                 $this->totPag = 2;
                 break;
-            case ($qtdeNFe <= 16):
+            case ($qtdeNFe <= 26):
                 $this->totPag = 1;
                 break;
         }
         $r = $this->zCabecalho(1, 1, '1', $this->totPag);
         $contador = 0;
         while ($contador < count($this->arrayNFe)) {
-            if ($contador == 15) {
+            if ($contador == 26) {
                 break;
             }
             $tp = 'NF-e';
@@ -2427,7 +2417,7 @@ class DacteV3 extends Common
     {
         $x2 = $x;
         $y2 = $y;
-        $contador = 16;
+        $contador = 26;
         for ($i = 2; $i <= $this->totPag; $i++) {
             $x = $x2;
             $y = $y2;


### PR DESCRIPTION
1.  Caso o xml tenha sido gerado na versão 2.00 a tag tomador não estava sendo encontrada. Assim o tomador não era impresso na Dacte.
2. Identificação pelo código da unidade e não mais pela posição no xml, sendo que isso forçava a criação da tag xml na posição 0 para unidade de medida KG(Quilos)
3. Quantidade de NF-e na página inicial para completar bloco em branco. Havia uma limitação de 15 notas sendo que o bloco comporta até 26.