### PR TITLE
Bug na verificação de tag existente DACTE

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -2932,7 +2932,7 @@ class Dacte extends Common
         $aFont = $this->formatPadrao;
         $this->pTextBox($x, $y, $w * 0.23, $h, $texto, $aFont, 'T', 'L', 0, '');
         if ($this->infNF->item(0) !== null 
-                && $this->infNF->item(0)->getElementsByTagName('infUnidCarga')->length > 0) {
+            && $this->infNF->item(0)->getElementsByTagName('infUnidCarga')->length > 0) {
             $texto = $this->infNF
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -2931,7 +2931,8 @@ class Dacte extends Common
         $texto = 'IDENTIFICAÇÃO DOS CONTEINERS';
         $aFont = $this->formatPadrao;
         $this->pTextBox($x, $y, $w * 0.23, $h, $texto, $aFont, 'T', 'L', 0, '');
-        if ($this->infNF->item(0) !== null && $this->infNF->item(0)->getElementsByTagName('infUnidCarga') !== null) {
+        if ($this->infNF->item(0) !== null 
+                && $this->infNF->item(0)->getElementsByTagName('infUnidCarga')->length > 0) {
             $texto = $this->infNF
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')
@@ -2939,7 +2940,7 @@ class Dacte extends Common
                 ->getElementsByTagName('idUnidCarga')
                 ->item(0)->nodeValue;
         } elseif ($this->infNFe->item(0) !== null
-            && $this->infNFe->item(0)->getElementsByTagName('infUnidCarga') !== null
+            && $this->infNFe->item(0)->getElementsByTagName('infUnidCarga')->length > 0
         ) {
             $texto = $this->infNFe
                 ->item(0)
@@ -2949,7 +2950,7 @@ class Dacte extends Common
                 ->item(0)
                 ->nodeValue;
         } elseif ($this->infOutros->item(0) !== null
-            && $this->infOutros->item(0)->getElementsByTagName('infUnidCarga') !== null
+            && $this->infOutros->item(0)->getElementsByTagName('infUnidCarga')->length > 0
         ) {
             $texto = $this->infOutros
                 ->item(0)

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -1766,7 +1766,8 @@ class Dacte extends Common
             'style' => '');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
         $texto = $this->pSimpleGetValue($this->infQ->item(1), "tpMed") . "\r\n";
-        $texto .= number_format(
+        $qCarga = $this->pSimpleGetValue($this->infQ->item(1), "qCarga");
+        $texto .= !empty($qCarga) ? number_format(
             $this->pSimpleGetValue(
                 $this->infQ->item(1),
                 "qCarga"
@@ -1777,7 +1778,7 @@ class Dacte extends Common
             3,
             ".",
             ""
-        );
+        ) : "";
         $texto = $this->pSimpleGetValue($this->infQ->item(1), "qCarga") == '' ? '' : $texto;
         $texto .= ' ' . $this->zUnidade($this->pSimpleGetValue($this->infQ->item(1), "cUnid"));
         $aFont = array(


### PR DESCRIPTION
A condição do if para verificar se existe o node retorna um objeto vazio e não null, devido a isso ele entrava no if e causava o `getElementsByTagName() on null` quando é chamada item(0) dentro do if.

EDIT 1:
Novo commit referênte ao tratamento de number_format apartir da versão 7.1, onde ele tentava fazer o format mas como o node 1 do atributo não existia, ele retornava uma string vazia e estourava um Exception 'non number'.


