### PR TITLE
Ajustes na verificação de tipo de pagamento

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1613,9 +1613,9 @@ class Danfe extends Common
             if (isset($fat)) {
                 $textoIndPag="";
                 $indPag = $this->pSimpleGetValue($this->ide, "indPag");
-                if ($indPag == 0) {
+                if ($indPag === 0) {
                     $textoIndPag = "Pagamento à Vista - ";
-                } elseif ($indPag == 1) {
+                } elseif ($indPag === 1) {
                     $textoIndPag = "Pagamento à Prazo - ";
                 }
                 $nFat = $this->pSimpleGetValue($fat, "nFat", "Fatura: ");

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1613,9 +1613,9 @@ class Danfe extends Common
             if (isset($fat)) {
                 $textoIndPag="";
                 $indPag = $this->pSimpleGetValue($this->ide, "indPag");
-                if ($indPag === 0) {
+                if ($indPag === "0") {
                     $textoIndPag = "Pagamento à Vista - ";
-                } elseif ($indPag === 1) {
+                } elseif ($indPag === "1") {
                     $textoIndPag = "Pagamento à Prazo - ";
                 }
                 $nFat = $this->pSimpleGetValue($fat, "nFat", "Fatura: ");


### PR DESCRIPTION
Ocorria que quando não houvesse conteúdo na tag indPag (na versão 4), o resultado de pSimpleGetValue era uma string vazia, entrando na validação de pagamento a vista.

Ajustado para utilizar o operador de comparação "identico", validando o tipo do resultado.