### PR TITLE
Update Danfe.php

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -825,6 +825,8 @@ class Danfe extends Common
         } else {
             $cdata = $parte2;
         }
+        //Retira a tag <FONTE IBPT> (caso existir) pois não é uma estrutura válida XML
+        $cdata = str_replace('<FONTE IBPT>', '', $cdata);
         //carrega o xml CDATA em um objeto DOM
         $dom = new Dom();
         $dom->loadXML($cdata, LIBXML_NOBLANKS | LIBXML_NOEMPTYTAG);


### PR DESCRIPTION
Foi adicionado tratamento caso exista a tag <FONTE IBPT> nas informações complementares da NF-e, pois alguns XMLs vinham com observação "<FONTE IBPT>" e na hora de gerar a DANFE ocorria erro no processamento do Dom.