### PR TITLE
correções visuais na Danfe e Dacce

### DIFF
--- a/src/NFe/Dacce.php
+++ b/src/NFe/Dacce.php
@@ -370,6 +370,7 @@ class Dacce extends Common
         // ############################################
         $x = $oldX;
         $y = $y1;
+        $texto = '';
         if ($this->CNPJDest != '') {
             $texto = 'CNPJ do Destinatário: ' . $this->pFormat($this->CNPJDest, "##.###.###/####-##");
         }

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -1138,6 +1138,15 @@ class Danfce extends Common
             case '13':
                 $tPagNome = 'Vale Combustível';
                 break;
+            case '14':
+                $tPagNome = 'Duplicata Mercantil';
+                break;
+            case '15':
+                $tPagNome = 'Boleto Bancário';
+                break;
+            case '90':
+                $tPagNome = 'Sem Pagamento';
+                break;
             case '99':
                 $tPagNome = 'Outros';
         }

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2219,7 +2219,7 @@ class Danfe extends Common
 
         if (!empty($ICMS)) {
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pRedBC", " pRedBC=%s%%");
-            $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pMVAST", " IVA=%s%%");
+            $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pMVAST", " IVA/MVA=%s%%");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "pICMSST", " pIcmsSt=%s%%");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "vBCST", " BcIcmsSt=%s");
             $impostos .= $this->pDescricaoProdutoHelper($ICMS, "vICMSST", " vIcmsSt=%s");


### PR DESCRIPTION
Atualizando a descrição do campo IVA para IVA/MVA na descrição do produto no layout da DANFE, o motivo é que o pessoal de testes da empresa que trabalho "reclamou" por que o termo IVA não é usado aqui no PR mas sim, MVA. 
Adicionando outras formas de pagamento que ainda não haviam sido adicionadas conforme a [NT_2016_002_v1.42](http://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=20k0jfiSgtk=)
Limpei a variável $texto antes de verificar se existe CNPJ ou CPF do destinatário, pois quando não encontrava nenhum dos dois, era inserido duas vezes o texto "De acordo com as determinações legais vigentes, vimos por meio desta comunicar-lhe.."