### PR TITLE
Erro de dependências

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php" : ">=5.6",
+        "nfephp-org/sped-common": "^5.0",
         "tecnickcom/tc-lib-barcode": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
Utilizo o pacote de forma independente do restante do projeto e notei este erro de dependências ao atualizar meu repositório:
"'PHP message: PHP Fatal error:  Uncaught Error: Class 'NFePHP\\Common\\Validator' not found in ..."