### PR TITLE
Suporte para PNG com Alpha Channel no PDF

### DIFF
--- a/src/Legacy/FPDF/Fpdf.php
+++ b/src/Legacy/FPDF/Fpdf.php
@@ -995,7 +995,7 @@ class Fpdf
         }
     }
     
-    public function image($file, $x = null, $y = null, $w = 0, $h = 0, $type = '', $link = '', $isMask = false, $maskImg = 0)
+    public function image($file, $x = null, $y = null, $w = 0, $h = 0, $type = '', $link = '', $mask = false, $img = 0)
     {
         //Put an image on the page
         if (!isset($this->images[$file])) {
@@ -1023,7 +1023,7 @@ class Fpdf
                 }
                 $info = $this->$mtd($file);
             }
-            if ($isMask) {
+            if ($mask) {
                 if (in_array($file, $this->tmpFiles)) {
                     $info['cs'] = 'DeviceGray'; //hack necessary as GD can't produce gray scale images
                 }
@@ -1035,8 +1035,8 @@ class Fpdf
                 }
             }
             $info['i'] = count($this->images)+1;
-            if ($maskImg > 0) {
-                $info['masked'] = $maskImg;
+            if ($img > 0) {
+                $info['masked'] = $img;
             }
             $this->images[$file] = $info;
         } else {
@@ -1070,8 +1070,17 @@ class Fpdf
         if ($x === null) {
             $x = $this->x;
         }
-        if (!$isMask) {
-            $this->out(sprintf('q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q', $w*$this->k, $h*$this->k, $x*$this->k, ($this->h-($y+$h))*$this->k, $info['i']));
+        if (!$mask) {
+            $this->out(
+                sprintf(
+                    'q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q',
+                    $w*$this->k,
+                    $h*$this->k,
+                    $x*$this->k,
+                    ($this->h-($y+$h))*$this->k,
+                    $info['i']
+                )
+            );
         }
         if ($link) {
             $this->link($x, $y, $w, $h, $link);

--- a/src/Legacy/FPDF/Fpdf.php
+++ b/src/Legacy/FPDF/Fpdf.php
@@ -1071,16 +1071,7 @@ class Fpdf
             $x = $this->x;
         }
         if (!$isMask) {
-            $this->out(
-                    sprintf(
-                        'q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q',
-                        $w*$this->k,
-                        $h*$this->k,
-                        $x*$this->k,
-                        ($this->h-($y+$h))*$this->k,
-                        $info['i']
-                    )
-            );
+            $this->out(sprintf('q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q', $w*$this->k, $h*$this->k, $x*$this->k, ($this->h-($y+$h))*$this->k, $info['i']));
         }
         if ($link) {
             $this->link($x, $y, $w, $h, $link);

--- a/src/Legacy/FPDF/Fpdf.php
+++ b/src/Legacy/FPDF/Fpdf.php
@@ -67,7 +67,7 @@ class Fpdf
     public $aliasNbPages;       //alias for total number of pages
     public $pdfVersion;         //PDF version number
     
-    var $tmpFiles = array();
+    private $tmpFiles = array();
     
     public function __construct($orientation = 'P', $unit = 'mm', $format = 'A4')
     {
@@ -315,8 +315,9 @@ class Fpdf
         $this->endPage();
         //Close document
         $this->endDoc();
-        foreach ($this->tmpFiles as $tmp)
+        foreach ($this->tmpFiles as $tmp) {
             @unlink($tmp);
+        }
     }
     
     public function addPage($orientation = '', $format = '')
@@ -1010,7 +1011,7 @@ class Fpdf
             if ($type == 'png') {
                 $info = $this->parsePNG($file);
                 if ($info == 'alpha') {
-                    return $this->ImagePngWithAlpha($file, $x, $y, $w, $h, $link);
+                    return $this->imagePngWithAlpha($file, $x, $y, $w, $h, $link);
                 }
             } else {
                 if ($type == 'jpeg') {
@@ -1389,8 +1390,9 @@ class Fpdf
     
     
     // GD seems to use a different gamma, this method is used to correct it again
-    function gamma($v) {
-        return pow($v/255,2.2)*255;
+    protected function gamma($v)
+    {
+        return pow($v/255, 2.2)*255;
     }
     
     
@@ -1762,7 +1764,7 @@ class Fpdf
     
     // needs GD 2.x extension
     // pixel-wise operation, not very fast
-    function ImagePngWithAlpha($file, $x, $y, $w=0, $h=0, $link='')
+    protected function imagePngWithAlpha($file, $x, $y, $w = 0, $h = 0, $link = '')
     {
         $tmp_alpha = tempnam('.', 'mska');
         $this->tmpFiles[] = $tmp_alpha;
@@ -1813,7 +1815,7 @@ class Fpdf
             $this->out('/Subtype /Image');
             $this->out('/Width '.$info['w']);
             $this->out('/Height '.$info['h']);
-            if (isset($info['masked'])){
+            if (isset($info['masked'])) {
                 $this->out('/SMask ' . ($this->n-1) . ' 0 R');
             }
             if ($info['cs']=='Indexed') {

--- a/src/Legacy/FPDF/Fpdf.php
+++ b/src/Legacy/FPDF/Fpdf.php
@@ -1017,7 +1017,7 @@ class Fpdf
                 if ($type == 'jpeg') {
                     $type = 'jpg';
                 }
-                $mtd = '_parse'.$type;
+                $mtd = 'parse'.strtoupper($type);
                 if (!method_exists($this, $mtd)) {
                     $this->error('Unsupported image type: '.$type);
                 }


### PR DESCRIPTION
Incluído suporte para PNG com Alpha Channel

O recurso consiste em criar arquivos de imagens temporárias de mascarás em escala de cinza e assim utilizar essa mascará para aplicar a transparência na imagem original, os arquivos temporários são destruídos após o PDF ser criado

Também há uma correção na chama da propriedade "pageBreakTrigger" que estava escrito com letra maiúscula