### PR TITLE
Alteração de nome da função para padronização

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -982,7 +982,7 @@ class Danfce extends Common
      */
     public function printDocument($nome = '', $destino = 'I', $printer = '')
     {
-        $arq = $this->printDANFE($nome, $destino, $printer);        
+        $arq = $this->printDANFE($nome, $destino, $printer);
         return $arq;
     }
     /**

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -955,12 +955,34 @@ class Danfce extends Common
      * @return string Caso o destino seja S o pdf é retornado como uma string
      * @todo   Rotina de impressão direta do arquivo pdf criado
      */
-    public function printDocument($nome = '', $destino = 'I', $printer = '')
+    public function printDANFE($nome = '', $destino = 'I', $printer = '')
     {
         $arq = $this->pdf->Output($nome, $destino);
         if ($destino == 'S') {
             //aqui pode entrar a rotina de impressão direta
         }
+        return $arq;
+    }
+    /**
+     * printDocument
+     * Esta função envia a DANFE em PDF criada para o dispositivo informado.
+     * O destino da impressão pode ser :
+     * I-browser
+     * D-browser com download
+     * F-salva em um arquivo local com o nome informado
+     * S-retorna o documento como uma string e o nome é ignorado.
+     * Para enviar o pdf diretamente para uma impressora indique o
+     * nome da impressora e o destino deve ser 'S'.
+     *
+     * @param  string $nome    Path completo com o nome do arquivo pdf
+     * @param  string $destino Direção do envio do PDF
+     * @param  string $printer Identificação da impressora no sistema
+     * @return string Caso o destino seja S o pdf é retornado como uma string
+     * @todo   Rotina de impressão direta do arquivo pdf criado
+     */
+    public function printDocument($nome = '', $destino = 'I', $printer = '')
+    {
+        $arq = $this->printDANFE($nome, $destino, $printer);        
         return $arq;
     }
     /**

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -955,7 +955,7 @@ class Danfce extends Common
      * @return string Caso o destino seja S o pdf é retornado como uma string
      * @todo   Rotina de impressão direta do arquivo pdf criado
      */
-    public function printDANFE($nome = '', $destino = 'I', $printer = '')
+    public function printDocument($nome = '', $destino = 'I', $printer = '')
     {
         $arq = $this->pdf->Output($nome, $destino);
         if ($destino == 'S') {


### PR DESCRIPTION
Alterada a função "printDANFE" para "printDocument" no arquivo "Danfce.php"

Essa alteração consiste em manter um padrão nos nomes das funções das classes "Danfe" e "Danfce", pois desta forma não há distinção entre as chamadas das funções para impressão da DANFe e DANFCe, permitido assim o programador chama-las de forma genérica por exemplo:

switch ($modelo) {
            case "55":
                $danfe = new Danfe($xml, $orientacao, $papel, $sPathLogo, $destino, $pathPDF);
                $id = $danfe->monta($orientacao, $papel, $posicaoLogo);               
                break;
            case "65":                
                $danfe = new Danfce($xml, $sPathLogo, $mododebug);
                $id = $danfe->monta($ecoNFCe);
                break;
            default:
                return '';
        }

$danfe->printDocument($fileName, $destino);