### PR TITLE
Desambiguação no total do FCP da UF destino

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1863,7 +1863,7 @@ class Danfe extends Common
 
         if ($this->exibirIcmsInterestadual) {
             $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "V. ICMS UF REMET.", "vICMSUFRemet");
-            $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "V. FCP UF REMET.", "vFCPUFDest");
+            $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "V. FCP UF DEST.", "vFCPUFDest");
         }
 
         if ($this->exibirPIS) {

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1863,7 +1863,7 @@ class Danfe extends Common
 
         if ($this->exibirIcmsInterestadual) {
             $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "V. ICMS UF REMET.", "vICMSUFRemet");
-            $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "VALOR DO FCP", "vFCPUFDest");
+            $x = $this->pImpostoDanfeHelper($x, $y, $w, $h, "V. FCP UF REMET.", "vFCPUFDest");
         }
 
         if ($this->exibirPIS) {


### PR DESCRIPTION
Na NF-e 4.00, há um totalizador para o valor do FCP da operação, desmembrado do total do ICMS.
O totalizador do FCP da DIFAL, sendo chamado de "Valor do FCP", é ambíguo. Mudei para "V. FCP UF Dest"
para que fique claro qual é o FCP tratado no campo.