### PR TITLE
Adição das formas de pagamento no DANFE

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1856,7 +1856,11 @@ class Danfe extends Common
                     ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
                 $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue)
                     ? 'R$ ' . number_format(
-                    $this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 2, ",", ".") : '';
+                        $this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 
+                        2, 
+                        ",", 
+                        "."
+                    ) : '';
                 $h = 6;
                 $texto = '';
                 if (isset($formaPagamento[$fPag])) {

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -756,9 +756,15 @@ class Danfe extends Common
                 $y = $y;
             } 
             else {
-                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a
-                //forma de pagamento e o valor
-                $y = $this->pagamentoDANFE($x, $y+1);
+                //Se somente tiver a forma de pagamento sem pagamento ou outros não imprimir nada
+                if (count($formaPag)=='1' && (isset($formaPag[90]) || isset($formaPag[99]))) {
+                    $y = $y;
+                } 
+                else {
+                    //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a
+                    //forma de pagamento e o valor
+                    $y = $this->pagamentoDANFE($x, $y+1);
+                }
             }
         }
         //coloca os dados dos impostos e totais da NFe

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -751,8 +751,14 @@ class Danfe extends Common
              && isset($formaPag[15]) && isset($formaPag[90])) {
             $y = $this->pFaturaDANFE($x, $y+1);
         } else {
-            //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
-            $y = $this->pagamentoDANFE($x, $y+1);
+            //Se somente tiver a forma de pagamento sem pagamento ou outros não imprimir nada
+            if ( count($formaPag)=='1' && (isset($formaPag[90]) || isset($formaPag[99])) ) {
+                $y = $y;
+            }
+            else {
+                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
+                $y = $this->pagamentoDANFE($x, $y+1);
+            }
         }
         //coloca os dados dos impostos e totais da NFe
         $y = $this->pImpostoDANFE($x, $y+1);

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -745,8 +745,10 @@ class Danfe extends Common
             }
         }
         //Caso só tenha pagamento em boleto exibe as faturas ou invés das formas
-        //caso tenha boleto e sem pagamento também exibir faturas pois deve ser devolução de materiais do destinatário e não tem cobrança
-        if ((count($formaPag)=='1' && isset($formaPag[15]) || count($formaPag)=='2' && isset($formaPag[15]) && isset($formaPag[90])) {
+        //caso tenha boleto e sem pagamento também exibir faturas pois deve ser devolução de
+        //materiais do destinatário e não tem cobrança
+        if ((count($formaPag)=='1' && isset($formaPag[15]) || count($formaPag)=='2' 
+             && isset($formaPag[15]) && isset($formaPag[90])) {
             $y = $this->pFaturaDANFE($x, $y+1);
         } 
         else {
@@ -1844,10 +1846,10 @@ class Danfe extends Common
                 $maxDupCont = 8;
             }
             $increm = 1;
-            $formaPagamento = array('01'=>'Dinheiro','02'=>'Cheque','03'=>'Cartão de Crédito','04'=>'Cartão de Débito',
-                                    '05'=>'Crédito Loja','10'=>'Vale Alimentação','11'=>'Vale Refeição',
-                                    '12'=>'Vale Presente','13'=>'Vale Combustível','14'=>'Duplicata Mercantil',
-                                    '15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
+            $formaPagamento = array('01'=>'Dinheiro','02'=>'Cheque','03'=>'Cartão de Crédito',
+                                    '04'=>'Cartão de Débito','05'=>'Crédito Loja','10'=>'Vale Alimentação',
+                                    '11'=>'Vale Refeição','12'=>'Vale Presente','13'=>'Vale Combustível',
+                                    '14'=>'Duplicata Mercantil','15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
             $bandeira = array('01'=>'Visa','02'=>'Mastercard','03'=>'American','04'=>'Sorocred','05'=>'Diners',
                               '06'=>'Elo','07'=>'Hipercard','08'=>'Aura','09'=>'Cabal','99'=>'Outros');
             foreach ($this->detPag as $k => $d) {
@@ -1859,7 +1861,7 @@ class Danfe extends Common
                 $texto = '';
                 if ( isset($formaPagamento[$fPag])) {
                     /*Exibir Item sem pagamento ou outros?*/
-                    if ( $fPag=='90' || $fPag=='99' ) {
+                    if ($fPag=='90' || $fPag=='99') {
                         continue;
                     }
                     $aFont = array('font'=>$this->fontePadrao, 'size'=>6, 'style'=>'');

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -737,17 +737,17 @@ class Danfe extends Common
         
         //Verifica as formas de pagamento da nota fiscal
         $formaPag = array();
-        if (isset($this->detPag) && $this->detPag->length > 0 ) {
-          foreach ($this->detPag as $k => $d) {
-             $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
-             $formaPag[$fPag] = $fPag;
-          }
+        if (isset($this->detPag) && $this->detPag->length > 0 ){
+            foreach ($this->detPag as $k => $d) {
+                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
+                $formaPag[$fPag] = $fPag;
+            }
         }
         //Caso só tenha pagamento em boleto exibe as faturas
-        if ( count($formaPag)=='1' && isset($formaPag[15]) ) {
+        if ( count($formaPag)=='1' && isset($formaPag[15]) ){
            $y = $this->pFaturaDANFE($x, $y+1);
         }
-        else {
+        else{
             //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
             $y = $this->pagamentoDANFE($x, $y+1);
         }
@@ -759,7 +759,7 @@ class Danfe extends Common
         $nInicial = 0;
         $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo1, $pag, $totPag, $hCabecItens);
         //coloca os dados do ISSQN
-        if ($linhaISSQN == 1) {
+        if ($linhaISSQN == 1){
             $y = $this->pIssqnDANFE($x, $y+4);
         } else {
             $y += 4;
@@ -767,13 +767,13 @@ class Danfe extends Common
         //coloca os dados adicionais da NFe
         $y = $this->pDadosAdicionaisDANFE($x, $y, $hdadosadic);
         //coloca o rodapé da página
-        if ($this->orientacao == 'P') {
+        if ($this->orientacao == 'P'){
             $this->pRodape($xInic, $y-1);
         } else {
             $this->pRodape($xInic, $this->hPrint + 1);
         }
         //loop para páginas seguintes
-        for ($n = 2; $n <= $totPag; $n++) {
+        for ($n = 2; $n <= $totPag; $n++){
             // fixa as margens
             $this->pdf->setMargins($margEsq, $margSup);
             //adiciona nova página
@@ -1257,17 +1257,17 @@ class Danfe extends Common
         // NOTA : DANFE sem protocolo deve existir somente no caso de contingência !!!
         // Além disso, existem várias NFes em contingência que eu recebo com protocolo de autorização.
         // Na minha opinião, deveríamos mostra-lo, mas o  manual  da NFe v4.01 diz outra coisa...
-        if (($this->tpEmis == 2 || $this->tpEmis == 5) && !$this->pNotaDPEC()) {
+        if (($this->tpEmis == 2 || $this->tpEmis == 5) && !$this->pNotaDPEC()){
             $aFont = array('font'=>$this->fontePadrao, 'size'=>8, 'style'=>'B');
             $texto = $this->pFormat($chaveContingencia, "#### #### #### #### #### #### #### #### ####");
             $cStat = '';
-        } else {
+        } else{
             $aFont = array('font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B');
-            if ($this->pNotaDPEC()) {
+            if ($this->pNotaDPEC()){
                 $texto = $this->numero_registro_dpec;
                 $cStat = '';
             } else {
-                if (isset($this->nfeProc)) {
+                if (isset($this->nfeProc)){
                     $texto = ! empty($this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue) ?
                             $this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue : '';
                     $tsHora = $this->pConvertTime($this->nfeProc->getElementsByTagName("dhRecbto")->item(0)->nodeValue);

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -752,11 +752,12 @@ class Danfe extends Common
             $y = $this->pFaturaDANFE($x, $y+1);
         } else {
             //Se somente tiver a forma de pagamento sem pagamento ou outros não imprimir nada
-            if ( count($formaPag)=='1' && (isset($formaPag[90]) || isset($formaPag[99])) ) {
+            if (count($formaPag)=='1' && (isset($formaPag[90]) || isset($formaPag[99]))) {
                 $y = $y;
             }
             else {
-                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
+                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a 
+                //forma de pagamento e o valor
                 $y = $this->pagamentoDANFE($x, $y+1);
             }
         }

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -747,11 +747,10 @@ class Danfe extends Common
         //Caso só tenha pagamento em boleto exibe as faturas ou invés das formas
         //caso tenha boleto e sem pagamento também exibir faturas pois deve ser devolução de
         //materiais do destinatário e não tem cobrança
-        if ((count($formaPag)=='1' && isset($formaPag[15]) || count($formaPag)=='2' 
+        if ((count($formaPag)=='1' && isset($formaPag[15]) || count($formaPag)=='2'
              && isset($formaPag[15]) && isset($formaPag[90])) {
             $y = $this->pFaturaDANFE($x, $y+1);
-        } 
-        else {
+        } else {
             //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
             $y = $this->pagamentoDANFE($x, $y+1);
         }
@@ -1856,10 +1855,11 @@ class Danfe extends Common
                 $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue)
                     ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
                 $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue)
-                    ? 'R$ ' . number_format($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 2, ",", ".") : '';
+                    ? 'R$ ' . number_format(
+                    $this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 2, ",", ".") : '';
                 $h = 6;
                 $texto = '';
-                if ( isset($formaPagamento[$fPag])) {
+                if (isset($formaPagamento[$fPag])) {
                     /*Exibir Item sem pagamento ou outros?*/
                     if ($fPag=='90' || $fPag=='99') {
                         continue;

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1856,9 +1856,9 @@ class Danfe extends Common
                     ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
                 $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue)
                     ? 'R$ ' . number_format(
-                        $this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 
-                        2, 
-                        ",", 
+                        $this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue,
+                        2,
+                        ",",
                         "."
                     ) : '';
                 $h = 6;

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1819,7 +1819,7 @@ class Danfe extends Common
         //verificar se existem cobranças definidas
         if (isset($this->detPag) && $this->detPag->length > 0) {
             //#####################################################################
-            //FATURA / DUPLICATA
+            //Tipo de pagamento
             $texto = "PAGAMENTO";
             if ($this->orientacao == 'P') {
                 $w = $this->wPrint;

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -739,15 +739,16 @@ class Danfe extends Common
         $formaPag = array();
         if (isset($this->detPag) && $this->detPag->length > 0) {
             foreach ($this->detPag as $k => $d) {
-                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? 
+                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ?
                     $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
                 $formaPag[$fPag] = $fPag;
             }
         }
-        //Caso só tenha pagamento em boleto exibe as faturas
-        if (count($formaPag)=='1' && isset($formaPag[15])) {
+        //Caso só tenha pagamento em boleto exibe as faturas ou invés das formas
+        //caso tenha boleto e sem pagamento também exibir faturas pois deve ser devolução de materiais do destinatário e não tem cobrança
+        if ((count($formaPag)=='1' && isset($formaPag[15]) || count($formaPag)=='2' && isset($formaPag[15]) && isset($formaPag[90])) {
             $y = $this->pFaturaDANFE($x, $y+1);
-        }
+        } 
         else {
             //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
             $y = $this->pagamentoDANFE($x, $y+1);
@@ -1264,11 +1265,11 @@ class Danfe extends Common
             $cStat = '';
         } else {
             $aFont = array('font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B');
-            if ($this->pNotaDPEC()){
+            if ($this->pNotaDPEC()) {
                 $texto = $this->numero_registro_dpec;
                 $cStat = '';
             } else {
-                if (isset($this->nfeProc)){
+                if (isset($this->nfeProc)) {
                     $texto = ! empty($this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue) ?
                             $this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue : '';
                     $tsHora = $this->pConvertTime($this->nfeProc->getElementsByTagName("dhRecbto")->item(0)->nodeValue);
@@ -1844,17 +1845,23 @@ class Danfe extends Common
             }
             $increm = 1;
             $formaPagamento = array('01'=>'Dinheiro','02'=>'Cheque','03'=>'Cartão de Crédito','04'=>'Cartão de Débito',
-                                    '05'=>'Crédito Loja','10'=>'Vale Alimentação','11'=>'Vale Refeição','12'=>'Vale Presente','13'=>'Vale Combustível','14'=>'Duplicata Mercantil','15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
+                                    '05'=>'Crédito Loja','10'=>'Vale Alimentação','11'=>'Vale Refeição',
+                                    '12'=>'Vale Presente','13'=>'Vale Combustível','14'=>'Duplicata Mercantil',
+                                    '15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
             $bandeira = array('01'=>'Visa','02'=>'Mastercard','03'=>'American','04'=>'Sorocred','05'=>'Diners',
                               '06'=>'Elo','07'=>'Hipercard','08'=>'Aura','09'=>'Cabal','99'=>'Outros');
             foreach ($this->detPag as $k => $d) {
-                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) 
+                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue)
                     ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
-                $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue) 
+                $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue)
                     ? 'R$ ' . number_format($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 2, ",", ".") : '';
                 $h = 6;
                 $texto = '';
                 if ( isset($formaPagamento[$fPag])) {
+                    /*Exibir Item sem pagamento ou outros?*/
+                    if ( $fPag=='90' || $fPag=='99' ) {
+                        continue;
+                    }
                     $aFont = array('font'=>$this->fontePadrao, 'size'=>6, 'style'=>'');
                     $this->pTextBox($x, $y, $w, $h, 'Forma', $aFont, 'T', 'L', 1, '');
                     $aFont = array('font'=>$this->fontePadrao, 'size'=>7, 'style'=>'B');

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -737,17 +737,18 @@ class Danfe extends Common
         
         //Verifica as formas de pagamento da nota fiscal
         $formaPag = array();
-        if (isset($this->detPag) && $this->detPag->length > 0 ){
+        if (isset($this->detPag) && $this->detPag->length > 0) {
             foreach ($this->detPag as $k => $d) {
-                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
+                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? 
+                    $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
                 $formaPag[$fPag] = $fPag;
             }
         }
         //Caso só tenha pagamento em boleto exibe as faturas
-        if ( count($formaPag)=='1' && isset($formaPag[15]) ){
-           $y = $this->pFaturaDANFE($x, $y+1);
+        if (count($formaPag)=='1' && isset($formaPag[15])) {
+            $y = $this->pFaturaDANFE($x, $y+1);
         }
-        else{
+        else {
             //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a forma de pagamento e o valor
             $y = $this->pagamentoDANFE($x, $y+1);
         }
@@ -759,7 +760,7 @@ class Danfe extends Common
         $nInicial = 0;
         $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo1, $pag, $totPag, $hCabecItens);
         //coloca os dados do ISSQN
-        if ($linhaISSQN == 1){
+        if ($linhaISSQN == 1) {
             $y = $this->pIssqnDANFE($x, $y+4);
         } else {
             $y += 4;
@@ -767,13 +768,13 @@ class Danfe extends Common
         //coloca os dados adicionais da NFe
         $y = $this->pDadosAdicionaisDANFE($x, $y, $hdadosadic);
         //coloca o rodapé da página
-        if ($this->orientacao == 'P'){
+        if ($this->orientacao == 'P') {
             $this->pRodape($xInic, $y-1);
         } else {
             $this->pRodape($xInic, $this->hPrint + 1);
         }
         //loop para páginas seguintes
-        for ($n = 2; $n <= $totPag; $n++){
+        for ($n = 2; $n <= $totPag; $n++) {
             // fixa as margens
             $this->pdf->setMargins($margEsq, $margSup);
             //adiciona nova página
@@ -1257,11 +1258,11 @@ class Danfe extends Common
         // NOTA : DANFE sem protocolo deve existir somente no caso de contingência !!!
         // Além disso, existem várias NFes em contingência que eu recebo com protocolo de autorização.
         // Na minha opinião, deveríamos mostra-lo, mas o  manual  da NFe v4.01 diz outra coisa...
-        if (($this->tpEmis == 2 || $this->tpEmis == 5) && !$this->pNotaDPEC()){
+        if (($this->tpEmis == 2 || $this->tpEmis == 5) && !$this->pNotaDPEC()) {
             $aFont = array('font'=>$this->fontePadrao, 'size'=>8, 'style'=>'B');
             $texto = $this->pFormat($chaveContingencia, "#### #### #### #### #### #### #### #### ####");
             $cStat = '';
-        } else{
+        } else {
             $aFont = array('font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B');
             if ($this->pNotaDPEC()){
                 $texto = $this->numero_registro_dpec;
@@ -1816,7 +1817,7 @@ class Danfe extends Common
         $h = 8+3;
         $oldx = $x;
         //verificar se existem cobranças definidas
-        if (isset($this->detPag) && $this->detPag->length > 0 ) {
+        if (isset($this->detPag) && $this->detPag->length > 0) {
             //#####################################################################
             //FATURA / DUPLICATA
             $texto = "PAGAMENTO";
@@ -1842,14 +1843,18 @@ class Danfe extends Common
                 $maxDupCont = 8;
             }
             $increm = 1;
-            $formaPagamento = array('01'=>'Dinheiro','02'=>'Cheque','03'=>'Cartão de Crédito','04'=>'Cartão de Débito','05'=>'Crédito Loja','10'=>'Vale Alimentação','11'=>'Vale Refeição','12'=>'Vale Presente','13'=>'Vale Combustível','14'=>'Duplicata Mercantil','15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
-            $bandeira = array('01'=>'Visa','02'=>'Mastercard','03'=>'American','04'=>'Sorocred','05'=>'Diners','06'=>'Elo','07'=>'Hipercard','08'=>'Aura','09'=>'Cabal','99'=>'Outros');
+            $formaPagamento = array('01'=>'Dinheiro','02'=>'Cheque','03'=>'Cartão de Crédito','04'=>'Cartão de Débito',
+                                    '05'=>'Crédito Loja','10'=>'Vale Alimentação','11'=>'Vale Refeição','12'=>'Vale Presente','13'=>'Vale Combustível','14'=>'Duplicata Mercantil','15'=>'Boleto','90'=>'Sem pagamento','99'=>'Outros');
+            $bandeira = array('01'=>'Visa','02'=>'Mastercard','03'=>'American','04'=>'Sorocred','05'=>'Diners',
+                              '06'=>'Elo','07'=>'Hipercard','08'=>'Aura','09'=>'Cabal','99'=>'Outros');
             foreach ($this->detPag as $k => $d) {
-                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
-                $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue) ? 'R$ ' . number_format($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue,2,",",".") : '';
+                $fPag = !empty($this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue) 
+                    ? $this->detPag->item($k)->getElementsByTagName('tPag')->item(0)->nodeValue : '0';
+                $vPag = ! empty($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue) 
+                    ? 'R$ ' . number_format($this->detPag->item($k)->getElementsByTagName('vPag')->item(0)->nodeValue, 2, ",", ".") : '';
                 $h = 6;
                 $texto = '';
-                if ( isset($formaPagamento[$fPag]) ) {
+                if ( isset($formaPagamento[$fPag])) {
                     $aFont = array('font'=>$this->fontePadrao, 'size'=>6, 'style'=>'');
                     $this->pTextBox($x, $y, $w, $h, 'Forma', $aFont, 'T', 'L', 1, '');
                     $aFont = array('font'=>$this->fontePadrao, 'size'=>7, 'style'=>'B');

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -806,7 +806,7 @@ class Danfe extends Common
                 $this->pRodape($xInic, $this->hPrint + 4);
             }
             //se estiver na última página e ainda restar itens para inserir, adiciona mais uma página
-            if ($n == $totPag && $this->qtdeItensProc < $qtdeItens) {
+            if ($n == $totPag && $this->qtdeItensProc < $qtdeItens) { 
                 $totPag++;
             }
         }

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -754,9 +754,9 @@ class Danfe extends Common
             //Se somente tiver a forma de pagamento sem pagamento ou outros não imprimir nada
             if (count($formaPag)=='1' && (isset($formaPag[90]) || isset($formaPag[99]))) {
                 $y = $y;
-            }
+            } 
             else {
-                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a 
+                //caso tenha mais de uma forma de pagamento ou seja diferente de boleto exibe a
                 //forma de pagamento e o valor
                 $y = $this->pagamentoDANFE($x, $y+1);
             }


### PR DESCRIPTION
Alguns cliente solicitaram que fossem exibidas as formas de pagamento no DANFE.
Gerei essa nova função pagamentoDANFE, baseada na  faturaDANFE. Usando o mesmo formato de impressão exibe a forma de pagamento e o valor.
Alterei para que fosse usada a pagamentoDANFE no lugar da faturaDANFE no caso de pagamentos que não sejam só boletos.
Talvez adicionar uma opção na criação da classe se é para exibir ou não o pagamento?