### PR TITLE
Update Danfce.php

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -1157,6 +1157,9 @@ class Danfce extends Common
                 break;
             case '99':
                 $tBandNome = 'OUTROS';
+                break;
+            default:
+                $tBandNome = '';
         }
         return $tBandNome;
     }


### PR DESCRIPTION
Quando $tBand é vazio e chama getCardName, por não possuir default no switch gera-se um warning de "variável não definida" e o PDF não é gerado.
Para corrigir adicionei o default no switch.