### PR TITLE
[UPD] box numero alinhado

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3201,7 +3201,7 @@ class Danfe extends Common
             $x--;
             $x = $this->pTextBox90($x, $y, $w-1, $h, $texto, $aFontSmall, 'C', 'L', 0, '', false);
             //NUMERO DA NOTA FISCAL LOGO NFE
-            $w1 = 16;
+            $w1 = 18;
             $x1 = $oldX;
             $y = $oldY;
             $texto = "NF-e";


### PR DESCRIPTION
O box da nfe fica desalinhado com ```$w1 = 16; ``` com ```$w1 = 18;``` fica alinhado

```$w1 = 16; ``` 
![captura de tela de 2018-10-10 14-55-43](https://user-images.githubusercontent.com/2566340/46756117-16d83500-cc9d-11e8-993d-6290e752fa51.png)

```$w1 = 18; ``` 
![captura de tela de 2018-10-10 14-56-01](https://user-images.githubusercontent.com/2566340/46756123-18a1f880-cc9d-11e8-810e-f0b1796e3adf.png)
