### PR TITLE
Retirado a palavra "Remetente" de "Destinatário/Remetente"

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1466,7 +1466,11 @@ class Danfe extends Common
         }
         $w = $maxW;
         $h = 7;
-        $texto = 'DESTINATÁRIO';
+        if ($this->ide->getElementsByTagName("tpNF")->item(0)->nodeValue==='0') {
+            $texto = 'REMETENTE';
+        } else {
+            $texto = 'DESTINATÁRIO';
+        }
         $aFont = array('font'=>$this->fontePadrao, 'size'=>7, 'style'=>'B');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
         //NOME / RAZÃO SOCIAL

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -1466,7 +1466,7 @@ class Danfe extends Common
         }
         $w = $maxW;
         $h = 7;
-        $texto = 'DESTINATÁRIO / REMETENTE';
+        $texto = 'DESTINATÁRIO';
         $aFont = array('font'=>$this->fontePadrao, 'size'=>7, 'style'=>'B');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
         //NOME / RAZÃO SOCIAL


### PR DESCRIPTION
Retirei a palavra Remetente que fica ao lado de "Destinatário".
O que causou foi que como no DANFE fica Destinatário / Remetente a abaixo fica os dados do destinatário, fica parecendo que o destinatário é o remetente, e caso o frete seja cobrado como 0(remetente) a transportadora quis cobrar do destinatário.
Eu sei que o que vale é o XML (0 = remetente).
Tem sentido deixar os dois valores?