### PR TITLE
[UPD] Decodifica os caracteres HTML na impressão (ISSUE #186)

### DIFF
--- a/src/Legacy/Common.php
+++ b/src/Legacy/Common.php
@@ -275,6 +275,8 @@ class Common
             $text = trim($text);
             //converter o charset para o fpdf
             $text = utf8_decode($text);
+            //decodifica os caracteres html no xml
+            $text = html_entity_decode($text);
         } else {
             $text = (string) $text;
         }
@@ -409,6 +411,8 @@ class Common
             $text = trim($text);
             //converter o charset para o fpdf
             $text = utf8_decode($text);
+            //decodifica os caracteres html no xml
+            $text = html_entity_decode($text);
         } else {
             $text = (string) $text;
         }


### PR DESCRIPTION
Como descrito na _ISSUE_ #186, os caracteres especiais — como o _ampersand_ (&) —  são codificados em caracteres _HTML_ validos para a geração do _XML_, mas não são decodificados para a impressão, causando problemas de visualização do PDF.

Esta correção adiciona o tratamento desses caracteres no texto que será inserido no _textBox_, os decodificando em caracteres _HUMAN-READABLE_.

> É necessário observar que na consulta da nota na _SEFAZ_ **a exibição é conforme o que está no XML**