### PR TITLE
Decodificação de caracteres html no campo descrição do produto

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2392,6 +2392,8 @@ class Danfe extends Common
                 ' FCI:'.$itemProd->getElementsByTagName('nFCI')->item(0)->nodeValue : '';
         $tmp_ad=$infAdProd . ($this->descProdInfoComplemento ? $loteTxt . $impostos . $nFCI : '');
         $texto = $prod->getElementsByTagName("xProd")->item(0)->nodeValue . (strlen($tmp_ad)!=0?"\n    ".$tmp_ad:'');
+        //decodifica os caracteres html no xml
+        $texto = html_entity_decode($texto);
         if ($this->descProdQuebraLinha) {
             $texto = str_replace(";", "\n", $texto);
         }


### PR DESCRIPTION
## Descrição Detalhada
- Foi colocado um html_entity_decode no método "pDescriçãoProduto" na danfe do NFe, para que os caracteres html sejam convertidos na hora da impressão da nota.