### PR TITLE
SEM INFORMAÇÃO DE QRCODE

### DIFF
--- a/src/CTe/DacteOSV3.php
+++ b/src/CTe/DacteOSV3.php
@@ -217,7 +217,7 @@ class DacteOSV3 extends Common
             $this->tpCTe = $this->getTagValue($this->ide, "tpCTe");
             $this->protCTe = $this->dom->getElementsByTagName("protCTe")->item(0);
             $this->qrCodMDFe = $this->dom->getElementsByTagName('qrCodCTe')->item(0) ?
-                $this->dom->getElementsByTagName('qrCodCTe')->item(0)->nodeValue : null;
+                $this->dom->getElementsByTagName('qrCodCTe')->item(0)->nodeValue : 'SEM INFORMAÇÃO DE QRCODE';
             //01-Rodoviário; //02-Aéreo; //03-Aquaviário; //04-Ferroviário;//05-Dutoviário
             $this->modal = $this->getTagValue($this->ide, "modal");
         }

--- a/src/CTe/DacteV3.php
+++ b/src/CTe/DacteV3.php
@@ -246,7 +246,7 @@ class DacteV3 extends Common
             $this->tpAmb = $this->getTagValue($this->ide, "tpAmb");
             $this->tpCTe = $this->getTagValue($this->ide, "tpCTe");
             $this->qrCodCTe = $this->dom->getElementsByTagName('qrCodCTe')->item(0) ?
-                $this->dom->getElementsByTagName('qrCodCTe')->item(0)->nodeValue : null;
+                $this->dom->getElementsByTagName('qrCodCTe')->item(0)->nodeValue : 'SEM INFORMAÇÃO DE QRCODE';
             $this->protCTe = $this->dom->getElementsByTagName("protCTe")->item(0);
             //01-Rodoviário; //02-Aéreo; //03-Aquaviário; //04-Ferroviário;//05-Dutoviário
             $this->modal = $this->getTagValue($this->ide, "modal");

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -201,7 +201,7 @@ class Damdfe extends Common
             $this->infMDFe->getAttribute("Id")
         );
         $this->qrCodMDFe = $this->dom->getElementsByTagName('qrCodMDFe')->item(0) ?
-            $this->dom->getElementsByTagName('qrCodMDFe')->item(0)->nodeValue : null;
+            $this->dom->getElementsByTagName('qrCodMDFe')->item(0)->nodeValue : 'SEM INFORMAÇÃO DE QRCODE';
         if (is_object($this->mdfeProc)) {
             $this->nProt = !empty($this->mdfeProc->getElementsByTagName("nProt")->item(0)->nodeValue) ?
                 $this->mdfeProc->getElementsByTagName("nProt")->item(0)->nodeValue : '';


### PR DESCRIPTION
Ajustado para que ao ser gerado o pdf de um CTe ou MDFe e o mesmo não possua a informação do QRCode no xml para que seja gerado a seguinte informação no QRCode: 'SEM INFORMAÇÃO DE QRCODE', com isso o layout não ira ficar desconfigurado.