### PR TITLE
Adicionando a leitura do detPag loadDoc

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -406,13 +406,18 @@ class Danfe extends Common
         //##################################################################
         //Verificando quantas linhas serão usadas para impressão das duplicatas
         $linhasDup = 0;
-        if (($this->dup->length > 0) && ($this->dup->length <= 7)) {
+        if (isset($this->dup) && $this->dup->length > 0) {
+            $qtdPag = $this->dup->length;
+        } elseif (isset($this->detPag) && $this->detPag->length > 0) {
+           $qtdPag = $this->detPag->length;
+        }
+        if (($qtdPag > 0) && ($qtdPag <= 7)) {
             $linhasDup = 1;
-        } elseif (($this->dup->length > 7) && ($this->dup->length <= 14)) {
+        } elseif (($qtdPag > 7) && ($qtdPag <= 14)) {
             $linhasDup = 2;
-        } elseif (($this->dup->length > 14) && ($this->dup->length <= 21)) {
+        } elseif (($qtdPag > 14) && ($qtdPag <= 21)) {
             $linhasDup = 3;
-        } elseif ($this->dup->length > 21) {
+        } elseif ($qtdPag > 21) {
             // chinnonsantos 11/05/2016: Limite máximo de impressão de duplicatas na NFe,
             // só vai ser exibito as 21 primeiras duplicatas (parcelas de pagamento),
             // se não oculpa espaço d+, cada linha comporta até 7 duplicatas.
@@ -3303,6 +3308,7 @@ class Danfe extends Common
             $this->transp = $this->dom->getElementsByTagName("transp")->item(0);
             $this->transporta = $this->dom->getElementsByTagName("transporta")->item(0);
             $this->veicTransp = $this->dom->getElementsByTagName("veicTransp")->item(0);
+            $this->detPag = $this->dom->getElementsByTagName("detPag");
             $this->reboque = $this->dom->getElementsByTagName("reboque")->item(0);
             $this->infAdic = $this->dom->getElementsByTagName("infAdic")->item(0);
             $this->compra = $this->dom->getElementsByTagName("compra")->item(0);


### PR DESCRIPTION
Adicionando a leitura do detPag no loadDoc para ser utilizada na função pagamento.
Também foi alterado a forma que é calculado a quantidade de linhas das duplicatas. Como existe a possibilidade de não haver duplicatas e sim outras formas de pagamento, verificando o total das formas de pagamento.
A ideia é que ao imprimir as formas de pagamento são exibidas duas linhas (forma e valor), na exibição das duplicatas são 3 (num, vencimento e valor), para cada item.
Não alterei a função pagamento mas talvez seja necessário alterar ela para aumentar a altura de cada item para que fique igual, em altura, das duplicatas.