### PR TITLE
Cte com Modal = Aquaviário

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -2789,16 +2789,16 @@ class Dacte extends Common
         $texto = 'IDENTIFICAÇÃO DOS CONTEINERS';
         $aFont = $this->formatPadrao;
         $this->pdf->textBox($x, $y, $w * 0.23, $h, $texto, $aFont, 'T', 'L', 0, '');
-        if ($this->infNF->item(0) !== null && $this->infNF->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null) {
+        if (($this->infNF->item(0) !== null)
+            && ($this->infNF->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null)) {
             $texto = $this->infNF
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')
                 ->item(0)
                 ->getElementsByTagName('idUnidCarga')
                 ->item(0)->nodeValue;
-        } elseif ($this->infNFe->item(0) !== null
-            && $this->infNFe->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null
-        ) {
+        } elseif (($this->infNFe->item(0) !== null)
+            && ($this->infNFe->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null)) {
             $texto = $this->infNFe
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')
@@ -2806,9 +2806,8 @@ class Dacte extends Common
                 ->getElementsByTagName('idUnidCarga')
                 ->item(0)
                 ->nodeValue;
-        } elseif ($this->infOutros->item(0) !== null
-            && $this->infOutros->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null
-        ) {
+        } elseif (($this->infOutros->item(0) !== null)
+            && ($this->infOutros->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null)) {
             $texto = $this->infOutros
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -2789,7 +2789,7 @@ class Dacte extends Common
         $texto = 'IDENTIFICAÇÃO DOS CONTEINERS';
         $aFont = $this->formatPadrao;
         $this->pdf->textBox($x, $y, $w * 0.23, $h, $texto, $aFont, 'T', 'L', 0, '');
-        if ($this->infNF->item(0) !== null && $this->infNF->item(0)->getElementsByTagName('infUnidCarga') !== null) {
+        if ($this->infNF->item(0) !== null && $this->infNF->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null) {
             $texto = $this->infNF
                 ->item(0)
                 ->getElementsByTagName('infUnidCarga')
@@ -2797,7 +2797,7 @@ class Dacte extends Common
                 ->getElementsByTagName('idUnidCarga')
                 ->item(0)->nodeValue;
         } elseif ($this->infNFe->item(0) !== null
-            && $this->infNFe->item(0)->getElementsByTagName('infUnidCarga') !== null
+            && $this->infNFe->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null
         ) {
             $texto = $this->infNFe
                 ->item(0)
@@ -2807,7 +2807,7 @@ class Dacte extends Common
                 ->item(0)
                 ->nodeValue;
         } elseif ($this->infOutros->item(0) !== null
-            && $this->infOutros->item(0)->getElementsByTagName('infUnidCarga') !== null
+            && $this->infOutros->item(0)->getElementsByTagName('infUnidCarga')->item(0)->nodeValue !== null
         ) {
             $texto = $this->infOutros
                 ->item(0)


### PR DESCRIPTION
Corrigido o tratamento no método modalAquaviario em Dacte quando a tag 'infUnidCarga' retorna null. Atualmente é testado se o objeto é null e não o valor, sendo assim retorna um erro.