### PR TITLE
Alteração da chamada da pTextBox na linha 876

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -873,7 +873,7 @@ class Danfce extends Common
         if ($this->nfeProc->getElementsByTagName("xMsg")) {
             $texto = $texto . ' ' . $this->nfeProc->getElementsByTagName("xMsg")->item(0)->nodeValue;
         }
-        $heigthText = $this->pTextBox($x, $y, $w, $hLinha, $texto, $aFontTit, 'C', 'C', 0, '', false);
+        $heigthText = $this->pdf->textBox($x, $y, $w, $hLinha, $texto, $aFontTit, 'C', 'C', 0, '', false);
         // seta o textbox do texto adicional
         $this->pdf->textBox($x, $y+3, $w-2, $hLinha-3, $this->textoAdic, $aFontTex, 'T', 'L', 0, '', false);
     }


### PR DESCRIPTION
Bom dia,

Por favor efetuar a alteração na linha 876, pois a chamada esta errada

Alteração da linha 876

$heigthText = $this->pTextBox($x, $y, $w, $hLinha, $texto, $aFontTit, 'C', 'C', 0, '', false);


Para:

$heigthText = $this->pdf->textBox($x, $y, $w, $hLinha, $texto, $aFontTit, 'C', 'C', 0, '', false);