### PR TITLE
Não mostrar impostos na descrição dos produtos

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -54,7 +54,7 @@ class Danfe extends Common
      * na descrição do produto, como por exemplo, informações sobre impostos.
      * @var boolean
      */
-    protected $descProdInfoComplemento = true;
+    public $descProdInfoComplemento = true;
     /**
      * Parâmetro do controle se deve gerar quebras de linha com "\n" a partir de ";" na descrição do produto.
      * @var boolean


### PR DESCRIPTION
existe o parâmetro que dá opção de escolher se desejamos que apareçam os impostos na descrição do produto ou não
mas ele não permite que seja alterado externamente, acaba que não está sendo possivel escolher.
se ele for publico, podemos configurar como quisermos.