### PR TITLE
Fix da NFe sem protocolo

### DIFF
--- a/src/CTe/Daevento.php
+++ b/src/CTe/Daevento.php
@@ -175,8 +175,7 @@ class Daevento extends Common
         $orientacao = '',
         $papel = 'A4',
         $logoAlign = 'C'
-    )
-    {
+    ) {
         if ($orientacao == '') {
             $orientacao = 'P';
         }
@@ -252,8 +251,7 @@ class Daevento extends Common
         $x,
         $y,
         $pag
-    )
-    {
+    ) {
         $oldX = $x;
         $oldY = $y;
         $maxW = $this->wPrint;

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3302,7 +3302,7 @@ class Danfe extends Common
         $this->pdf->textBox($x, $y+2, $w-2, $h-3, $this->textoAdic, $aFont, 'T', 'L', 0, '', false);
         //RESERVADO AO FISCO
         $texto = "RESERVADO AO FISCO";
-        if ($this->nfeProc->getElementsByTagName("xMsg")) {
+        if (isset($this->nfeProc) && $this->nfeProc->getElementsByTagName("xMsg")) {
             $texto = $texto . ' ' . $this->nfeProc->getElementsByTagName("xMsg")->item(0)->nodeValue;
         }
         $x += $w;


### PR DESCRIPTION
Fix do erro: "Call to a member function getElementsByTagName() on null => line 3305" quando é gerado a pré-visualização de uma NFe (de devolução) sem prótocolo.