### PR TITLE
Impressão Inscrição Municipal

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -435,7 +435,7 @@ class Danfe extends Common
         }
         //verifica se será impressa a linha dos serviços ISSQN
         $linhaISSQN = 0;
-        if (!empty($this->emit->getElementsByTagName("IM")->item(0)->nodeValue)) {
+        if ((isset($this->ISSQNtot)) && ($this->getTagValue($this->ISSQNtot, 'vServ') > 0)) {
             $linhaISSQN = 1;
         }
         //calcular a altura necessária para os dados adicionais
@@ -1197,7 +1197,7 @@ class Danfe extends Common
         $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
         //####################################################################################
         //INSCRIÇÃO ESTADUAL
-        $w = round($maxW * 0.333, 0);
+        $w = round($maxW * 0.250, 0);
         $y += $h;
         $oldY += $h;
         $x = $oldX;
@@ -1205,6 +1205,14 @@ class Danfe extends Common
         $aFont = ['font'=>$this->fontePadrao, 'size'=>6, 'style'=>''];
         $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 1, '');
         $texto = $this->getTagValue($this->emit, "IE");
+        $aFont = ['font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B'];
+        $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
+        //INSCRIÇÃO MUNICIPAL
+        $x += $w;
+        $texto = 'INSCRIÇÃO MUNICIPAL';
+        $aFont = ['font'=>$this->fontePadrao, 'size'=>6, 'style'=>''];
+        $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 1, '');
+        $texto = $this->getTagValue($this->emit, "IM");
         $aFont = ['font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B'];
         $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
         //INSCRIÇÃO ESTADUAL DO SUBST. TRIBUT.
@@ -1219,10 +1227,7 @@ class Danfe extends Common
         $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
         //CNPJ
         $x += $w;
-        $w = ($maxW-(2*$w));
-        $texto = 'CNPJ / CPF';
-        $aFont = ['font'=>$this->fontePadrao, 'size'=>6, 'style'=>''];
-        $this->pdf->textBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 1, '');
+        $w = ($maxW-(3 * $w));
         //Pegando valor do CPF/CNPJ
         if (! empty($this->emit->getElementsByTagName("CNPJ")->item(0)->nodeValue)) {
             $texto = $this->formatField(

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -435,7 +435,7 @@ class Danfe extends Common
         }
         //verifica se será impressa a linha dos serviços ISSQN
         $linhaISSQN = 0;
-        if ((isset($this->ISSQNtot)) && ($this->getTagValue($this->ISSQNtot, 'vServ') > 0)) {
+        if (!empty($this->emit->getElementsByTagName("IM")->item(0)->nodeValue)) {
             $linhaISSQN = 1;
         }
         //calcular a altura necessária para os dados adicionais


### PR DESCRIPTION
Habilitar Impressão da IM, para casos em que a cidade não tenha Nota Conjugada.