### PR TITLE
Link quebrado

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ou ainda alterando o composer.json do seu aplicativo inserindo:
 ```
 
 ## Forma de uso
-[DANFE](DANFE.md) 
+[DANFE](docs/DANFE.md) 
 
 ## Log de mudanças e versões
 Acompanhe o [CHANGELOG](CHANGELOG.md) para maiores informações sobre as alterações recentes.


### PR DESCRIPTION
Arquivo DANFE foi movido para a pasta DOCS e não atualizado
Alteração ocorreu no commit e753af89b11e49461ac2fca024c2a7a235682262 de 05/Maio/2017