### PR TITLE
Correção Danfe.php

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3324,7 +3324,7 @@ class Danfe extends Common
         $this->pdf->textBox($x, $y+2, $w-2, $h-3, $this->textoAdic, $aFont, 'T', 'L', 0, '', false);
         //RESERVADO AO FISCO
         $texto = "RESERVADO AO FISCO";
-        if (isset($this->nfeProc) && $this->nfeProc->getElementsByTagName("xMsg")) {
+        if (isset($this->nfeProc) && $this->nfeProc->getElementsByTagName("xMsg")->length) {
             $texto = $texto . ' ' . $this->nfeProc->getElementsByTagName("xMsg")->item(0)->nodeValue;
         }
         $x += $w;


### PR DESCRIPTION
No estado do RS o campo "xMsg" é opcional e dá erro na linha 3328 devido a não existir nenhuma mensagem no XML.
Para solucionar adicionei um "length" na linha 3327 que fará a verificação se existem algum item dentro antes.