### PR TITLE
Variavel duplicada

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -317,7 +317,6 @@ class Danfce extends DaCommon
             $logoHmm = ($logoInfo[1]/72)*25.4;
             $nImgW = 30;
             $nImgH = round($logoHmm * ($nImgW/$logoWmm), 0);
-            $yImg = $margemInterna + $nImgH/2;
             $this->pdf->image($this->logomarca, $xImg, $yImg, $nImgW, $nImgH, 'jpeg');
             $xRs = ($maxW*0.4) + $margemInterna;
             $wRs = ($maxW*0.6);


### PR DESCRIPTION
Removido a linha 320 ( $yImg = $margemInterna + $nImgH/2; ), pois estava recalculando a posição da imagem, com isso fazendo ela ser impressa no final da espaço em branco, sobrepondo a mensagem "Documento auxiliar....."