### PR TITLE
Correção modal, aumento da caixa de texto das observações

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -322,7 +322,7 @@ class Dacte extends DaCommon
             $r = $this->impostos($x, $y);
             $y += 13;
             $x = $xInic;
-            if ($this->detCont->length > 0) {
+            if ($this->modal == '3') {
                 $r = $this->detCont($x, $y);
             } else {
                 $r = $this->docOrig($x, $y);
@@ -430,7 +430,7 @@ class Dacte extends DaCommon
         if ($this->modal == 3) {
             if ($this->flagDetContContinuacao == 1) {
                 $this->detContContinuacao(1, 71);
-            } else if ($this->flagDocOrigContinuacao == 1) {
+            } elseif ($this->flagDocOrigContinuacao == 1) {
                 $this->docOrigContinuacao(1, 71);
             }
         } else {

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -150,7 +150,7 @@ class Damdfe extends DaCommon
             }
         }
     }
-    
+
     protected function monta(
         $logo = ''
     ) {
@@ -1172,7 +1172,12 @@ class Damdfe extends DaCommon
     {
         $maxW = $this->wPrint;
         $x2 = $maxW;
-        $this->pdf->textBox($x, $y, $x2, 30);
+        if ($this->orientacao == 'P') {
+            $h = 145;
+        } else {
+            $h = 45;
+        }
+        $this->pdf->textBox($x, $y, $x2, $h);
         $texto = 'Observação
         ' . $this->infCpl;
         $aFont = array('font' => $this->fontePadrao, 'size' => 8, 'style' => '');


### PR DESCRIPTION
Quando modal não for do tipo aquaviário a tag **detCont** não existe no xml.

Sugestão de aumento da autura da caixa de texto.
Quando na observação contém muita informação a impressão fica cortada, conforme imagem abaixo:

![screenshot--2020 07 06-09_27_02](https://user-images.githubusercontent.com/1163778/86593242-3a600a80-bf6b-11ea-903c-174b0a737fac.png)
