### PR TITLE
Ajuste formato dos impostos quando zerados.

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2019,7 +2019,7 @@ class Danfe extends DaCommon
      */
     protected function impostoHelper($x, $y, $w, $h, $titulo, $campoImposto)
     {
-        $valorImposto = '0, 00';
+        $valorImposto = '0,00';
         $the_field = $this->ICMSTot->getElementsByTagName($campoImposto)->item(0);
         if (isset($the_field)) {
             $the_value = $the_field->nodeValue;
@@ -2818,7 +2818,7 @@ class Danfe extends DaCommon
                         ",",
                         "."
                     )
-                    : '0, 00';
+                    : '0,00';
                     $this->pdf->textBox($x, $y, $w11, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 }
                 //Valor do ICMS
@@ -2831,7 +2831,7 @@ class Danfe extends DaCommon
                         ",",
                         "."
                     )
-                    : '0, 00';
+                    : '0,00';
                     $this->pdf->textBox($x, $y, $w12, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 }
                 //Valor do IPI
@@ -2859,7 +2859,7 @@ class Danfe extends DaCommon
                         ",",
                         "."
                     )
-                    : '0, 00';
+                    : '0,00';
                     $this->pdf->textBox($x, $y, $w14, $h, $texto, $aFont, 'T', 'C', 0, '');
                 }
                 //%IPI


### PR DESCRIPTION
Quando não há valor para algumas colunas dos itens no DANFe, está sendo formatado como '0, 00' (com um espaço entre o separador e os decimais). Este formato de números é incorreto