### PR TITLE
Adiciona flag externa de cancelamento

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -932,7 +932,7 @@ class Dacte extends DaCommon
         $tpAmb = $this->ide->getElementsByTagName('tpAmb')->item(0)->nodeValue;
         //indicar cancelamento
         $cStat = $this->getTagValue($this->cteProc, "cStat");
-        if ($cStat == '101' || $cStat == '135') {
+        if ($cStat == '101' || $cStat == '135' || $this->cancelFlag === true) {
             //101 Cancelamento
             $x = 10;
             $y = $this->hPrint - 130;

--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -788,7 +788,7 @@ class DacteOS extends DaCommon
         $tpAmb = $this->ide->getElementsByTagName('tpAmb')->item(0)->nodeValue;
         //indicar cancelamento
         $cStat = $this->getTagValue($this->cteProc, "cStat");
-        if ($cStat == '101' || $cStat == '135') {
+        if ($cStat == '101' || $cStat == '135' || $this->cancelFlag === true) {
             //101 Cancelamento
             $x = 10;
             $y = $this->hPrint - 130;

--- a/src/Common/DaCommon.php
+++ b/src/Common/DaCommon.php
@@ -101,6 +101,10 @@ class DaCommon extends Common
      * @var int
      */
     protected $decimalPlaces;
+    /**
+     * @var bool
+     */
+    protected $cancelFlag = false;
 
     /**
      * Ativa ou desativa o modo debug
@@ -314,5 +318,14 @@ class DaCommon extends Common
         $logo = ob_get_contents(); // read from buffer
         ob_end_clean();
         return 'data://text/plain;base64,'.base64_encode($logo);
+    }
+
+    /**
+     * Atribui uma sinalização de cancelamento externa
+     * @param bool $cancelFlag
+     */
+    public function setCancelFlag($cancelFlag = true)
+    {
+        $this->cancelFlag = filter_var($cancelFlag, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -498,7 +498,7 @@ class Damdfe extends DaCommon
             $texto = "AMBIENTE DE HOMOLOGAÇÃO";
             $this->pdf->textBox($x, $yy + 14, $w, $h, $texto, $aFont, 'C', 'C', 0, '');
             $this->pdf->setTextColor(0, 0, 0);
-        } elseif ($cStat->item(0)->nodeValue == '101') {
+        } elseif ($cStat->item(0)->nodeValue == '101' || $this->cancelFlag === true) {
             $x = 10;
             if ($this->orientacao == 'P') {
                 $yy = round($this->hPrint * 2 / 3, 0);

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -1025,7 +1025,8 @@ class Danfce extends DaCommon
         return $cStat == '101' ||
                 $cStat == '151' ||
                 $cStat == '135' ||
-                $cStat == '155';
+                $cStat == '155' ||
+                $this->cancelFlag === true;
     }
 
     protected function checkDenegada()

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -812,6 +812,7 @@ class Danfe extends DaCommon
             || $cStat == '151'
             || $cStat == '135'
             || $cStat == '155'
+            || $this->cancelFlag === true
         ) {
             return ['status' => false, 'message' => 'NFe CANCELADA'];
         }


### PR DESCRIPTION
Alteração simples para suportar uma sinalização externa de cancelamento nos documentos. Útil para trabalhar com arquivos XML que não seguem o padrão adotado pela biblioteca de atualizar o XML original com o protocolo de cancelamento. Tem relação com #374 

Não altera nenhuma regra e tem a mesma prioridade que o protocolo de cancelamento para impressão da marca d'agua.

Estou aberto a sugestões e posso alterar a implementação conforme desejarem.