### PR TITLE
Correçao para impressao das chaves de CTe vinculada em documentos transp. anterior

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -145,6 +145,7 @@ class Dacte extends DaCommon
             $this->infNF = $this->dom->getElementsByTagName("infNF");
             $this->infNFe = $this->dom->getElementsByTagName("infNFe");
             $this->infOutros = $this->dom->getElementsByTagName("infOutros");
+            $this->idDocAntEle = $this->dom->getElementsByTagName("idDocAntEle");
             $this->infCTeMultimodal = $this->dom->getElementsByTagName("infCTeMultimodal");
             $this->compl = $this->dom->getElementsByTagName("compl");
             $this->ICMS = $this->dom->getElementsByTagName("ICMS")->item(0);
@@ -2654,7 +2655,7 @@ class Dacte extends DaCommon
         }
         foreach ($this->idDocAntEle as $k => $d) {
             $tp = 'CT-e';
-            $chaveCTe = $this->idDocAntEle->item($k)->getElementsByTagName('chave')->item(0)->nodeValue;
+            $chaveCTe = $this->idDocAntEle->item($k)->getElementsByTagName('chCTe')->item(0)->nodeValue;
             $numCTe = substr($chaveCTe, 25, 9);
             $serieCTe = substr($chaveCTe, 22, 3);
             $doc = $serieCTe . '/' . $numCTe;


### PR DESCRIPTION
A tag de documento anterior não era carregada, e o nome da tag que contem a chave de CTe estava incorreta.