### PR TITLE
Verificar se já existe logomarca. Se sim, não retornar null no método adjustImage

### DIFF
--- a/src/Common/DaCommon.php
+++ b/src/Common/DaCommon.php
@@ -270,6 +270,9 @@ class DaCommon extends Common
      */
     protected function adjustImage($logo, $turn_bw = false)
     {
+        if (!empty($this->logomarca)) {
+            return $this->logomarca;
+        }
         if (empty($logo)) {
             return null;
         }


### PR DESCRIPTION
Se o atributo logomarca já foi inicializado (principalmente pelo metodo $danfe->logoParameters($logo, 'C', false);)
O método adjustImage não retornará null quando for chamado pelo método $danfe->render();