### PR TITLE
Adição de DANFe Simplificado para Etiqueta 100x150mm

### DIFF
--- a/examples/nfe/danfesimples.php
+++ b/examples/nfe/danfesimples.php
@@ -17,10 +17,14 @@ try {
     /*  $danfe->depecNumber('123456789'); */
     //Configura a posicao da logo
     /*  $danfe->logoParameters($logo, 'C', false);  */
+    //Configura o tamanho do papel. O padrão é A5,
+        // $danfe->papel = 'A5';
+    //mandar array com o tamanho para o caso etiquetas de tamanhos personalizados.
+        // $danfe->papel = [100, 150];
     //Gera o PDF
     $pdf = $danfe->render($logo);
     header('Content-Type: application/pdf');
     echo $pdf;
 } catch (InvalidArgumentException $e) {
     echo "Ocorreu um erro durante o processamento :" . $e->getMessage();
-}    
+}

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -271,7 +271,7 @@ class DanfeSimples extends DaCommon
 
         // LINHA 3
         $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "NUMERL", 1, 0, 'C', 1);
+        $this->pdf->cell($c1, 5, "NUMERO", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->cell($c1, 5, "{$this->nfeArray['NFe']['infNFe']['ide']['nNF']}", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', 'B', 10);

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -352,7 +352,14 @@ class DanfeSimples extends DaCommon
 
         // LINHA 7
         $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
-        $this->pdf->multiCell(($c1 * 4), $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['emit']['xNome']}", 1, 'C', false);
+        $this->pdf->multiCell(
+            ($c1 * 4),
+            $pequeno ? 4 : 5,
+            "{$this->nfeArray['NFe']['infNFe']['emit']['xNome']}",
+            1,
+            'C',
+            false
+        );
 
         // LINHA 8
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['emit']['CNPJ'])

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -219,18 +219,35 @@ class DanfeSimples extends DaCommon
         if (empty($this->orientacao)) {
             $this->orientacao = 'L';
         }
+
+
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
         if ($this->orientacao == 'L') {
             if ($this->papel == 'A5') {
                 $this->maxW = 210;
                 $this->maxH = 148;
+            } elseif (is_array($this->papel)) {
+                $this->maxW = $this->papel[0];
+                $this->maxH = $this->papel[1];
             }
         } else {
             if ($this->papel == 'A5') {
                 $this->maxW = 148;
                 $this->maxH = 210;
+            } elseif (is_array($this->papel)) {
+                $this->maxW = $this->papel[0];
+                $this->maxH = $this->papel[1];
             }
         }
+
+        //Caso a largura da etiqueta seja pequena <=110mm,
+        //Definimos como pequeno, para diminuir as fontes e tamanhos das células
+        if ($this->maxW <= 130) {
+            $pequeno = true;
+        } else {
+            $pequeno = false;
+        }
+
         // estabelece contagem de paginas
         $this->pdf->aliasNbPages();
         // fixa as margens
@@ -243,16 +260,27 @@ class DanfeSimples extends DaCommon
         $this->pdf->addPage($this->orientacao, $this->papel);
         $this->pdf->setLineWidth(0.1);
         $this->pdf->settextcolor(0, 0, 0);
+        //Configura o pagebreak para não quebrar com 2cm do bottom.
+        $this->pdf->setAutoPageBreak(true, $this->margsup);
+
 
         // LINHA 1
-        $this->pdf->setFont('Arial', 'B', 12);
-        $this->pdf->cell(($this->maxW - ($this->margesq * 2)), 6, "DANFE SIMPLIFICADO - ETIQUETA", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(
+            ($this->maxW - ($this->margesq * 2)),
+            $pequeno ? 5 : 6,
+            "DANFE SIMPLIFICADO - ETIQUETA",
+            1,
+            1,
+            'C',
+            1
+        );
 
         // LINHA 2
         $dataEmissao = date('d/m/Y', strtotime("{$this->nfeArray['NFe']['infNFe']['ide']['dhEmi']}"));
         $c1 = ($this->maxW - ($this->margesq * 2)) / 4;
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "TIPO NF", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "TIPO NF", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->cell(
             $c1,
@@ -264,82 +292,120 @@ class DanfeSimples extends DaCommon
             'C',
             1
         );
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "DATA EMISSAO", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "DATA EMISSAO", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell($c1, 5, "{$dataEmissao}", 1, 1, 'C', 1);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$dataEmissao}", 1, 1, 'C', 1);
 
         // LINHA 3
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "NUMERO", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "NUMERO", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell($c1, 5, "{$this->nfeArray['NFe']['infNFe']['ide']['nNF']}", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "SERIE", 1, 0, 'C', 1);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['ide']['nNF']}", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "SERIE", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell($c1, 5, "{$this->nfeArray['NFe']['infNFe']['ide']['serie']}", 1, 1, 'C', 1);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['ide']['serie']}", 1, 1, 'C', 1);
 
         // LINHA 4
         $chave = substr($this->nfeArray['NFe']['infNFe']['@attributes']['Id'], 3);
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "CHAVE DE ACESSO", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 3), 5, "{$chave}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 7 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "CHAVE DE ACESSO", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+        $this->pdf->cell(($c1 * 3), $pequeno ? 4 : 5, "{$chave}", 1, 1, 'C', 1);
 
         // LINHA 5
-        $this->pdf->setFont('Arial', 'B', 10);
-        $this->pdf->cell($c1, 5, "PROTOCOLO", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 8 : 10);
+        $this->pdf->cell($c1, $pequeno ? 4 : 5, "PROTOCOLO", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
         $dataProto = date("d/m/Y H:i:s", strtotime($this->nfeArray['protNFe']['infProt']['dhRecbto']));
-        $this->pdf->cell(($c1 * 3), 5, "{$this->nfeArray['protNFe']['infProt']['nProt']} - {$dataProto}", 1, 1, 'C', 1);
+        $this->pdf->cell(
+            ($c1 * 3),
+            $pequeno ? 4 : 5,
+            "{$this->nfeArray['protNFe']['infProt']['nProt']} - {$dataProto}",
+            1,
+            1,
+            'C',
+            1
+        );
 
         $this->pdf->ln();
         $y = $this->pdf->getY();
         $this->pdf->setFillColor(0, 0, 0);
-        $this->pdf->code128(($c1/2), $y, $chave, ($c1 * 3), 15);
+        if ($pequeno) {
+            //caso seja etiqueta pequena, aumenta o code128 para
+            //que uma impressora de 203dpi consiga imprimir um código legível
+            $this->pdf->code128($this->margesq * 2, $y, $chave, ($this->maxW - $this->margesq * 4), 15);
+        } else {
+            $this->pdf->code128(($c1/2), $y, $chave, ($c1 * 3), 15);
+        }
         $this->pdf->setFillColor(255, 255, 255);
+        $this->pdf->ln();
         $this->pdf->ln();
         $this->pdf->ln();
         $this->pdf->ln();
         $this->pdf->ln();
 
         // LINHA 6
-        $this->pdf->setFont('Arial', 'B', 12);
-        $this->pdf->cell(($c1 * 4), 6, "EMITENTE", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "EMITENTE", 1, 1, 'C', 1);
 
         // LINHA 7
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 4), 5, "{$this->nfeArray['NFe']['infNFe']['emit']['xNome']}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->multiCell(($c1 * 4), $pequeno ? 4 : 5, "{$this->nfeArray['NFe']['infNFe']['emit']['xNome']}", 1, 'C', false);
 
         // LINHA 8
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['emit']['CNPJ'])
             ? $this->nfeArray['NFe']['infNFe']['emit']['CNPJ']
             :$this->nfeArray['NFe']['infNFe']['emit']['CPF']);
-        $this->pdf->cell(($c1 * 2), 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
-        $this->pdf->cell(($c1 * 2), 5, @"RG/IE {$this->nfeArray['NFe']['infNFe']['emit']['IE']}", 1, 1, 'C', 1);
+        $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
+        $this->pdf->cell(
+            ($c1 * 2),
+            $pequeno ? 4 : 5,
+            @"RG/IE {$this->nfeArray['NFe']['infNFe']['emit']['IE']}",
+            1,
+            1,
+            'C',
+            1
+        );
 
         $enderecoEmit  = "{$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['xMun']}"
                        . " / {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['UF']}"
                        . " - CEP {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['CEP']}";
 
         // LINHA 9
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 4), 5, "{$enderecoEmit}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoEmit}", 1, 1, 'C', 1);
 
         // LINHA 10
-        $this->pdf->setFont('Arial', 'B', 12);
-        $this->pdf->cell(($c1 * 4), 6, "DESTINATARIO", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DESTINATARIO", 1, 1, 'C', 1);
 
         // LINHA 11
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 4), 5, "{$this->nfeArray['NFe']['infNFe']['dest']['xNome']}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->multiCell(
+            ($c1 * 4),
+            $pequeno ? 4 : 5,
+            "{$this->nfeArray['NFe']['infNFe']['dest']['xNome']}",
+            1,
+            'C',
+            false
+        );
 
         // LINHA 12
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['dest']['CNPJ'])
             ? $this->nfeArray['NFe']['infNFe']['dest']['CNPJ']
             :$this->nfeArray['NFe']['infNFe']['dest']['CPF']);
-        $this->pdf->cell(($c1 * 2), 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
-        $this->pdf->cell(($c1 * 2), 5, @"RG/IE {$this->nfeArray['NFe']['infNFe']['dest']['IE']}", 1, 1, 'C', 1);
+        $this->pdf->cell(($c1 * 2), $pequeno ? 4 : 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
+        $this->pdf->cell(
+            ($c1 * 2),
+            $pequeno ? 4 : 5,
+            @"RG/IE {$this->nfeArray['NFe']['infNFe']['dest']['IE']}",
+            1,
+            1,
+            'C',
+            1
+        );
 
         if (isset($this->nfeArray['NFe']['infNFe']['entrega'])) {
             $enderecoLinha1 = "{$this->nfeArray['NFe']['infNFe']['entrega']['xLgr']}";
@@ -368,26 +434,34 @@ class DanfeSimples extends DaCommon
         }
 
         // LINHA 13
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 4), 5, "{$enderecoLinha1}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha1}", 1, 1, 'C', 1);
 
         // LINHA 14
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->cell(($c1 * 4), 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
 
         // LINHA 15
-        $this->pdf->setFont('Arial', 'B', 12);
-        $this->pdf->cell(($c1 * 2), 6, "TOTAL DA NF-e", 1, 0, 'C', 1);
-        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(($c1 * 2), $pequeno ? 5 : 6, "TOTAL DA NF-e", 1, 0, 'C', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
         $vNF = number_format($this->nfeArray['NFe']['infNFe']['total']['ICMSTot']['vNF'], 2, ',', '.');
-        $this->pdf->cell(($c1 * 2), 6, "R$ {$vNF}", 1, 1, 'C', 1);
+        $this->pdf->cell(($c1 * 2), $pequeno ? 5 : 6, "R$ {$vNF}", 1, 1, 'C', 1);
 
         // LINHA 16
-        $this->pdf->setFont('Arial', 'B', 12);
-        $this->pdf->cell(($c1 * 4), 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
+        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+        $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
 
         // LINHA 11
-        $this->pdf->setFont('Arial', '', 10);
-        $this->pdf->multiCell(($c1 * 4), 5, "{$this->nfeArray['NFe']['infNFe']['infAdic']['infCpl']}", 1, 1, 'J', 1);
+        $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+        $this->pdf->multiCell(
+            ($c1 * 4),
+            $pequeno ? 3 : 5,
+            "{$this->nfeArray['NFe']['infNFe']['infAdic']['infCpl']}",
+            1,
+            1,
+            'J',
+            1
+        );
     }
 }

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -318,15 +318,23 @@ class DanfeSimples extends DaCommon
         $this->pdf->cell(($c1 * 2), 5, "CNPJ/CPF {$cpfCnpj}", 1, 0, 'C', 1);
         $this->pdf->cell(($c1 * 2), 5, @"RG/IE {$this->nfeArray['NFe']['infNFe']['emit']['IE']}", 1, 1, 'C', 1);
 
+        $enderecoEmit  = "{$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['xMun']}"
+                       . " / {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['UF']}"
+                       . " - CEP {$this->nfeArray['NFe']['infNFe']['emit']['enderEmit']['CEP']}";
+
         // LINHA 9
+        $this->pdf->setFont('Arial', '', 10);
+        $this->pdf->cell(($c1 * 4), 5, "{$enderecoEmit}", 1, 1, 'C', 1);
+
+        // LINHA 10
         $this->pdf->setFont('Arial', 'B', 12);
         $this->pdf->cell(($c1 * 4), 6, "DESTINATARIO", 1, 1, 'C', 1);
 
-        // LINHA 10
+        // LINHA 11
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->cell(($c1 * 4), 5, "{$this->nfeArray['NFe']['infNFe']['dest']['xNome']}", 1, 1, 'C', 1);
 
-        // LINHA 11
+        // LINHA 12
         $cpfCnpj = (isset($this->nfeArray['NFe']['infNFe']['dest']['CNPJ'])
             ? $this->nfeArray['NFe']['infNFe']['dest']['CNPJ']
             :$this->nfeArray['NFe']['infNFe']['dest']['CPF']);
@@ -359,26 +367,26 @@ class DanfeSimples extends DaCommon
                              . " - CEP {$this->nfeArray['NFe']['infNFe']['dest']['enderDest']['CEP']}";
         }
 
-        // LINHA 12
+        // LINHA 13
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->cell(($c1 * 4), 5, "{$enderecoLinha1}", 1, 1, 'C', 1);
 
-        // LINHA 13
+        // LINHA 14
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->cell(($c1 * 4), 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
 
-        // LINHA 14
+        // LINHA 15
         $this->pdf->setFont('Arial', 'B', 12);
         $this->pdf->cell(($c1 * 2), 6, "TOTAL DA NF-e", 1, 0, 'C', 1);
         $this->pdf->setFont('Arial', '', 10);
         $vNF = number_format($this->nfeArray['NFe']['infNFe']['total']['ICMSTot']['vNF'], 2, ',', '.');
         $this->pdf->cell(($c1 * 2), 6, "R$ {$vNF}", 1, 1, 'C', 1);
 
-        // LINHA 15
+        // LINHA 16
         $this->pdf->setFont('Arial', 'B', 12);
         $this->pdf->cell(($c1 * 4), 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
 
-        // LINHA 16
+        // LINHA 11
         $this->pdf->setFont('Arial', '', 10);
         $this->pdf->multiCell(($c1 * 4), 5, "{$this->nfeArray['NFe']['infNFe']['infAdic']['infCpl']}", 1, 1, 'J', 1);
     }


### PR DESCRIPTION
-Modificado para suportar a geração de DANFe simplificado para etiqueta térmica 100x150, que é padrão no e-commerce.

![P_20210112_084529](https://user-images.githubusercontent.com/23251131/104311619-37af1680-54b4-11eb-939e-bccfeff947df.jpg)
