### PR TITLE
Exception $endPos

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -707,6 +707,9 @@ class Danfe extends DaCommon
                 break;
             }
         }
+        if ($x === 0) {
+            return $cdata;
+        }
         if ($startPos > 0) {
             $parte1 = substr($cdata, 0, $startPos);
         } else {


### PR DESCRIPTION
Mensagem do Exception: **Undefined variable: endPos**

Erro quando não encontra o caractere **>** no for.
O ajuste é consistente e gerou a Danfe como esperado.