### PR TITLE
Inclusão do valor do frete na DANFC-e

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -67,7 +67,7 @@ class Danfce extends DaCommon
     protected $bloco2H = 12.0; //informação fiscal
     
     protected $bloco3H = 0.0; //itens
-    protected $bloco4H = 13.0; //totais
+    protected $bloco4H = 16.0; //totais
     protected $bloco5H = 0.0; //formas de pagamento
     
     protected $bloco6H = 10.0; //informação para consulta

--- a/src/NFe/Traits/TraitBlocoIV.php
+++ b/src/NFe/Traits/TraitBlocoIV.php
@@ -10,21 +10,22 @@ trait TraitBlocoIV
     protected function blocoIV($y)
     {
         //$this->bloco4H = 13;
-        
+
         //$aFont = ['font'=> $this->fontePadrao, 'size' => 7, 'style' => ''];
         //$this->pdf->textBox($this->margem, $y, $this->wPrint, $this->bloco4H, '', $aFont, 'T', 'C', true, '', false);
-        
+
         $qtd = $this->det->length;
         $valor = $this->getTagValue($this->ICMSTot, 'vNF');
         $desconto = $this->getTagValue($this->ICMSTot, 'vDesc');
+        $frete = $this->getTagValue($this->ICMSTot, 'vFrete');
         $bruto = $valor + $desconto;
-        
-        $aFont = ['font'=> $this->fontePadrao, 'size' => 8, 'style' => ''];
+
+        $aFont = ['font' => $this->fontePadrao, 'size' => 8, 'style' => ''];
         $texto = "Qtde total de itens";
         $this->pdf->textBox(
             $this->margem,
             $y,
-            $this->wPrint/2,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -35,9 +36,9 @@ trait TraitBlocoIV
             false
         );
         $y1 = $this->pdf->textBox(
-            $this->margem+$this->wPrint/2,
+            $this->margem + $this->wPrint / 2,
             $y,
-            $this->wPrint/2,
+            $this->wPrint / 2,
             3,
             $qtd,
             $aFont,
@@ -47,12 +48,12 @@ trait TraitBlocoIV
             '',
             false
         );
-        
+
         $texto = "Valor Total R$";
         $this->pdf->textBox(
             $this->margem,
-            $y+$y1,
-            $this->wPrint/2,
+            $y + $y1,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -64,9 +65,9 @@ trait TraitBlocoIV
         );
         $texto = number_format((float) $bruto, 2, ',', '.');
         $y2 = $this->pdf->textBox(
-            $this->margem+$this->wPrint/2,
-            $y+$y1,
-            $this->wPrint/2,
+            $this->margem + $this->wPrint / 2,
+            $y + $y1,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -76,12 +77,12 @@ trait TraitBlocoIV
             '',
             false
         );
-        
+
         $texto = "Desconto R$";
         $this->pdf->textBox(
             $this->margem,
-            $y+$y1+$y2,
-            $this->wPrint/2,
+            $y + $y1 + $y2,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -93,9 +94,38 @@ trait TraitBlocoIV
         );
         $texto = number_format((float) $desconto, 2, ',', '.');
         $y3 = $this->pdf->textBox(
-            $this->margem+$this->wPrint/2,
-            $y+$y1+$y2,
-            $this->wPrint/2,
+            $this->margem + $this->wPrint / 2,
+            $y + $y1 + $y2,
+            $this->wPrint / 2,
+            3,
+            $texto,
+            $aFont,
+            'T',
+            'R',
+            false,
+            '',
+            false
+        );
+
+        $texto = "Frete R$";
+        $this->pdf->textBox(
+            $this->margem,
+            $y + $y1 + $y2 + $y3,
+            $this->wPrint / 2,
+            3,
+            $texto,
+            $aFont,
+            'T',
+            'L',
+            false,
+            '',
+            false
+        );
+        $texto = number_format((float) $frete, 2, ',', '.');
+        $y4 = $this->pdf->textBox(
+            $this->margem + $this->wPrint / 2,
+            $y + $y1 + $y2 + $y3,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -109,12 +139,12 @@ trait TraitBlocoIV
         if ($this->paperwidth < 70) {
             $fsize = 8;
         }
-        $aFont = ['font'=> $this->fontePadrao, 'size' => $fsize, 'style' => 'B'];
+        $aFont = ['font' => $this->fontePadrao, 'size' => $fsize, 'style' => 'B'];
         $texto = "Valor a Pagar R$";
         $this->pdf->textBox(
             $this->margem,
-            $y+$y1+$y2+$y3,
-            $this->wPrint/2,
+            $y + $y1 + $y2 + $y3 + $y4,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -126,9 +156,9 @@ trait TraitBlocoIV
         );
         $texto = number_format((float) $valor, 2, ',', '.');
         $y4 = $this->pdf->textBox(
-            $this->margem+$this->wPrint/2,
-            $y+$y1+$y2+$y3,
-            $this->wPrint/2,
+            $this->margem + $this->wPrint / 2,
+            $y + $y1 + $y2 + $y3 + $y4,
+            $this->wPrint / 2,
             3,
             $texto,
             $aFont,
@@ -138,8 +168,8 @@ trait TraitBlocoIV
             '',
             false
         );
-        
-        $this->pdf->dashedHLine($this->margem, $this->bloco4H+$y, $this->wPrint, 0.1, 30);
+
+        $this->pdf->dashedHLine($this->margem, $this->bloco4H + $y, $this->wPrint, 0.1, 30);
         return $this->bloco4H + $y;
     }
 }


### PR DESCRIPTION
Inclusão da impressão do valor do frete conforme manual de orientação. O frete é necessário para NFC-e com entrega à domicílio.

![image](https://user-images.githubusercontent.com/6354258/111869997-7b147e00-8958-11eb-927b-17e9d941f6ed.png)
