### PR TITLE
Altura do Bloco1 DANFCE para Arial

### DIFF
--- a/src/NFe/Traits/TraitBlocoI.php
+++ b/src/NFe/Traits/TraitBlocoI.php
@@ -72,7 +72,7 @@ trait TraitBlocoI
         $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
         $texto = $emitMun . "-" . $emitUF;
         $y += $this->pdf->textBox($xRs+2, $y, $wRs-2, 3, $texto, $aFont, 'T', $alignH, false, '', true);
-        $this->pdf->dashedHLine($this->margem, $this->bloco1H, $this->wPrint, 0.1, 30);
+        $this->pdf->dashedHLine($this->margem, $this->bloco1H + ($this->fontePadrao == 'arial' ? 1 : 0), $this->wPrint, 0.1, 30);
         return $this->bloco1H;
     }
 }


### PR DESCRIPTION
Ao gerar a DANFCE, quando alterado para fonte Arial, a última linha do texto no Bloco 1 ficava por cima da linha tracejada, ajustado pelo pull request.

![DANFCE Antes](https://user-images.githubusercontent.com/77071812/114752734-00f3d100-9d2d-11eb-9314-9dbab651ea59.png)

![DANFCE Depois](https://user-images.githubusercontent.com/77071812/114752805-15d06480-9d2d-11eb-8ae3-6a8708586bb8.png)