### PR TITLE
Remove echo indevido

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -412,7 +412,6 @@ class Danfe extends DaCommon
                 $numlinhasdados         = $this->pdf->getNumLines($this->textoAdic, $this->wAdic, $fontProduto) + 3;
                 $this->textadicfontsize = $this->pdf->fontSize;
                 $hdadosadic             = ceil($numlinhasdados * $this->textadicfontsize);
-                echo $hdadosadic;
                 if ($hdadosadic <= 90) {
                     $hdadosadic = ceil($hdadosadic);
                     break;


### PR DESCRIPTION
Comando `echo` indevido na geração do DANFe estava causando problemas ao gerar o documento e devolver em uma requisição, pois adiciona este conteúdo ao corpo da resposta.