### PR TITLE
Ajusta exibição dos itens descritivos do veículo

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3083,7 +3083,7 @@ class Danfe extends DaCommon
                 // Tag somente é gerada para veiculo 0k, e só é permitido um veiculo por NF-e por conta do detran
                 // Verifica se a Tag existe
                 if (! empty($veicProd)) {
-                    $this->dadosItenVeiculoDANFE($oldX, $y, $nInicio, $h, $prod);
+                    $this->dadosItenVeiculoDANFE($oldX + 3, $y + 40, $nInicio, 3, $prod);
                 }
 
 


### PR DESCRIPTION
Os dados (chassi, cor, cilindrada...) estavam sobrepondo os itens.

Atual:
![image](https://user-images.githubusercontent.com/1840969/125518268-6a2466b7-01f6-44cf-a6ff-a0ba9041b140.png)

Alteração:
![image](https://user-images.githubusercontent.com/1840969/125518365-b131d1ee-3b7a-4513-b061-10b170913f98.png)

Desde já agradeço a atenção.
Cordialmente,
