### PR TITLE
Proteções e melhorias na geraçāo do Danfe Simples

### DIFF
--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -282,10 +282,10 @@ class DanfeSimples extends DaCommon
             if (!isset($volumes[$vol['esp']])) {
                 $volumes[$vol['esp']] = 0;
             }
-            $volumes[$vol['esp']] += $vol['qVol'];
-            $totalVolumes += $vol['qVol'];
-            $pesoB += $vol['pesoB'];
-            $pesoL += $vol['pesoL'];
+            $volumes[$vol['esp']] += @$vol['qVol']; // Caso a quantidade de volumes não esteja presente no XML, soma-se zero
+            $totalVolumes += @$vol['qVol'] ?: 0; // Caso a quantidade de volumes não esteja presente no XML, soma-se zero
+            $pesoB += @$vol['pesoB'] ?: 0; // Caso o peso bruto não esteja presente no XML, soma-se zero
+            $pesoL += @$vol['pesoL'] ?: 0; // Caso o peso liquido não esteja presente no XML, soma-se zero
         }
 
         // LINHA 1
@@ -520,7 +520,6 @@ class DanfeSimples extends DaCommon
 
         $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
-
         $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
         $this->pdf->multiCell(
             ($c1 * 4),

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -267,14 +267,14 @@ class DanfeSimples extends DaCommon
         $pesoL = 0.000;
         $pesoB = 0.000;
         $totalVolumes = 0;
-        
+
         // Normalizar o array de volumes quando tem apenas 1 volumes
         if (!isset($this->nfeArray['NFe']['infNFe']['transp']['vol'][0])) {
             $this->nfeArray['NFe']['infNFe']['transp']['vol'] = [
                 $this->nfeArray['NFe']['infNFe']['transp']['vol']
             ];
         }
-        
+
         foreach ($this->nfeArray['NFe']['infNFe']['transp']['vol'] as $vol) {
             if (!isset($volumes[$vol['esp']])) {
                 $volumes[$vol['esp']] = 0;
@@ -284,7 +284,7 @@ class DanfeSimples extends DaCommon
             $pesoB += $vol['pesoB'];
             $pesoL += $vol['pesoL'];
         }
-        
+
         // LINHA 1
         $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
         $this->pdf->cell(
@@ -467,19 +467,21 @@ class DanfeSimples extends DaCommon
         $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
         $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
 
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
-        $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "TRANSPORTADORA", 1, 1, 'C', 1);
-        $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
-        $this->pdf->cell(
-            ($c1 * 4),
-            $pequeno ? 5 : 6,
-            "{$this->nfeArray['NFe']['infNFe']['transp']['transporta']['xNome']}",
-            1,
-            1,
-            'C',
-            1
-        );
-        
+        if($this->nfeArray['NFe']['infNFe']['transp']['modFrete'] != 9){
+            $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+            $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "TRANSPORTADORA", 1, 1, 'C', 1);
+            $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
+            $this->pdf->cell(
+                ($c1 * 4),
+                $pequeno ? 5 : 6,
+                "{$this->nfeArray['NFe']['infNFe']['transp']['transporta']['xNome']}",
+                1,
+                1,
+                'C',
+                1
+            );
+        }
+
         if ($totalVolumes > 0) {
             foreach ($volumes as $esp => $qVol) {
                 $this->pdf->cell(
@@ -493,10 +495,10 @@ class DanfeSimples extends DaCommon
                 );
             }
         }
-        
+
         $pesoL = number_format($pesoL, 3, ',', '.');
         $pesoB = number_format($pesoB, 3, ',', '.');
-        
+
         $this->pdf->cell(
             ($c1 * 4),
             $pequeno ? 5 : 6,

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -518,17 +518,19 @@ class DanfeSimples extends DaCommon
         $vNF = number_format($this->nfeArray['NFe']['infNFe']['total']['ICMSTot']['vNF'], 2, ',', '.');
         $this->pdf->cell(($c1 * 2), $pequeno ? 5 : 6, "R$ {$vNF}", 1, 1, 'C', 1);
 
-        $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
-        $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
-        $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
-        $this->pdf->multiCell(
-            ($c1 * 4),
-            $pequeno ? 3 : 5,
-            "{$this->nfeArray['NFe']['infNFe']['infAdic']['infCpl']}",
-            1,
-            1,
-            'J',
-            1
-        );
+        if(isset($this->nfeArray['NFe']['infNFe']['infAdic'])){
+            $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
+            $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "DADOS ADICIONAIS", 1, 1, 'C', 1);
+            $this->pdf->setFont('Arial', '', $pequeno ? 8 : 10);
+            $this->pdf->multiCell(
+                ($c1 * 4),
+                $pequeno ? 3 : 5,
+                "{$this->nfeArray['NFe']['infNFe']['infAdic']['infCpl']}",
+                1,
+                1,
+                'J',
+                1
+            );
+        }
     }
 }

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -276,6 +276,9 @@ class DanfeSimples extends DaCommon
         }
 
         foreach ($this->nfeArray['NFe']['infNFe']['transp']['vol'] as $vol) {
+            if(!isset($vol['esp'])){ // Espécie não especificada na transportadora (por erro de preenchimento do XML)
+                continue;
+            }
             if (!isset($volumes[$vol['esp']])) {
                 $volumes[$vol['esp']] = 0;
             }


### PR DESCRIPTION
Segue uma lista de correções:

* Gerar o Danfe simples mesmo sem as tags de transportadora. Refere-se a issue #477 .
* Se o volume nāo estiver presente no XML, omitir célula correspondente
* Se o volume estiver presente mas sem as informaçōes de peso, soma-se zero.
* Se informações adicionais nāo estiverem presentes, nāo monta a célula correspondente.