### PR TITLE
fix(dacte): corrige mascara de telefone celulares

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -3718,7 +3718,9 @@ class Dacte extends DaCommon
             $fone = !empty($field->getElementsByTagName("fone")->item(0)->nodeValue) ?
                 $field->getElementsByTagName("fone")->item(0)->nodeValue : '';
             $foneLen = strlen($fone);
-            if ($foneLen > 0) {
+            if ($foneLen == 11 && $fone[0] != 0) {
+                $fone = '('.substr($fone, 0, 2).') '.substr($fone, 2, 5). '-' . substr($fone, 7);
+            } else if ($foneLen > 0) {
                 $fone2 = substr($fone, 0, $foneLen - 4);
                 $fone1 = substr($fone, 0, $foneLen - 8);
                 $fone = '(' . $fone1 . ') ' . substr($fone2, -4) . '-' . substr($fone, -4);


### PR DESCRIPTION
Corrige máscara de celulares: 

De (xx9) 9999-8888 para (xx) 99999-8888
![Velho Fone](https://user-images.githubusercontent.com/66074971/130456315-38314fe2-454d-4ba8-ab3c-cae1228ee61d.PNG)
![Novo Fone](https://user-images.githubusercontent.com/66074971/130456316-8bb1bbdd-9089-44bf-927c-df4601393242.PNG)
