### PR TITLE
Ajusta box e descrição das Formas de pagamento

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2062,12 +2062,12 @@ class Danfe extends DaCommon
             $dups    = "";
             $dupcont = 0;
             if ($this->orientacao == 'P') {
-                $w = round($this->wPrint / 7.018, 0) - 1;
+                $w = round($this->wPrint / 3.968, 0) - 1;
             } else {
                 $w = 28;
             }
             if ($this->orientacao == 'P') {
-                $maxDupCont = 6;
+                $maxDupCont = 3;
             } else {
                 $maxDupCont = 8;
             }
@@ -2086,8 +2086,8 @@ class Danfe extends DaCommon
                 '15' => 'Boleto',
                 '16' => 'Depósito Bancário',
                 '17' => 'Pagamento Instantâneo (PIX)',
-                '18' => 'Transferência bancária, Carteira Digital',
-                '19' => 'Programa de fidelidade, Cashback, Crédito Virtual',
+                '18' => 'Transferência Bancária, Carteira Digit.',
+                '19' => 'Fidelidade, Cashback, Crédito Virtual',
                 '90' => 'Sem pagamento',
                 '99' => 'Outros'
             ];


### PR DESCRIPTION
Limita a 4 box por linha, aumenta horizontalmente a box, diminui a descrição das formas 18 e 19.

![2021-09-08 08_12_02-VirtualBoxVM](https://user-images.githubusercontent.com/16154651/132499498-499d5cba-b302-4e2e-8a31-d518f24b3c80.jpg)

