### PR TITLE
Fix: Danfe Nfc-e mostra como cancelada se cStat = 150

### DIFF
--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -414,7 +414,7 @@ class Danfce extends DaCommon
             ? $this->dom->getElementsByTagName('urlChave')->item(0)->nodeValue : null;
         if (!empty($this->infProt)) {
             $cStat = $this->getTagValue($this->infProt, 'cStat');
-            if ($cStat != 100) {
+            if ($this->isCanceledByProt()) {
                 $this->canceled = true;
             } elseif (!empty($retEvento = $this->nfeProc->getElementsByTagName('retEvento')->item(0))) {
                 $infEvento = $retEvento->getElementsByTagName('infEvento')->item(0);
@@ -440,4 +440,18 @@ class Danfce extends DaCommon
             }
         }
     }
+
+    /**
+     * Retorna se está cancelada baseado no protocolo (infProt)
+     * 
+     * @return bool
+     */
+    protected function isCanceledByProt() {
+        $cStat = $this->getTagValue($this->infProt, 'cStat');
+        return !in_array($cStat, [
+            100, // cStat = 100 - uso autorizado
+            150  // cStat = 150 - uso autorizado fora de prazo
+        ]);
+    }
+
 }


### PR DESCRIPTION
Quando a nota está "Autotizada Fora do Prazo" mostra a escrita "Cancelada" no centro do Danfe Nfc-e, nesse caso a nota está autorizado o uso.

Fiz uma função separada para fazer o teste, caso precise acrecentar outra futuramente pode-se usar ele.