### PR TITLE
Fix: Mostrar Protocolo e Data Autorização quando transmitida

### DIFF
--- a/src/NFe/Traits/TraitBlocoVII.php
+++ b/src/NFe/Traits/TraitBlocoVII.php
@@ -40,6 +40,14 @@ trait TraitBlocoVII
         if ($this->paperwidth < 70) {
             $subSize = 1.5;
         }
+
+        $protocolo = '';
+        $dhRecbto = '';
+        if (!empty($this->nfeProc)) {
+            $protocolo = $this->formatField($this->getTagValue($this->nfeProc, 'nProt'), '### ########## ##');
+            $dhRecbto = (new \DateTime($this->getTagValue($this->nfeProc, "dhRecbto")))->format('d/m/Y H:i:s');
+        }
+
         if ($this->tpEmis == 9) {
             $aFont = ['font'=> $this->fontePadrao, 'size' => (7-$subSize), 'style' => ''];
             $y += 2*$yPlus;
@@ -108,22 +116,31 @@ trait TraitBlocoVII
                 '',
                 true
             );
-            
-            $texto = "Pendente de autorização";
-            $aFont = ['font'=> $this->fontePadrao, 'size' => 8, 'style' => 'I'];
-            $y5 = $this->pdf->textBox(
-                $this->margem,
-                $y+$y1+$y2+$y3+$y4,
-                $this->wPrint,
-                3,
-                $texto,
-                $aFont,
-                'B',
-                'C',
-                false,
-                '',
-                true
-            );
+
+            if( empty($protocolo) ) {
+                $texto = "Pendente de autorização";
+                $aFont = ['font'=> $this->fontePadrao, 'size' => 8, 'style' => 'I'];
+                $y5 = $this->pdf->textBox(
+                    $this->margem,
+                    $y+$y1+$y2+$y3+$y4,
+                    $this->wPrint,
+                    3,
+                    $texto,
+                    $aFont,
+                    'B',
+                    'C',
+                    false,
+                    '',
+                    true
+                );
+            } else {
+                $this->blocoVII_prot(
+                    $y+$y1+$y2+$y3+$y4,
+                    $subSize,
+                    $protocolo, 
+                    $dhRecbto
+                );
+            }
         } elseif ($this->tpEmis == 4) {
             $aFont = ['font'=> $this->fontePadrao, 'size' => 7, 'style' => ''];
             $y1 = $this->pdf->textBox(
@@ -243,46 +260,48 @@ trait TraitBlocoVII
                 true
             );
 
-            $protocolo = '';
-            $data = '';
-            if (!empty($this->nfeProc)) {
-                $protocolo = $this->formatField($this->getTagValue($this->nfeProc, 'nProt'), '### ########## ##');
-                $data = (new \DateTime($this->getTagValue($this->nfeProc, "dhRecbto")))->format('d/m/Y H:i:s');
-            }
-            
-            $texto = "Protocolo de Autorização:  {$protocolo}";
-            $aFont = ['font'=> $this->fontePadrao, 'size' => (8-$subSize), 'style' => ''];
-            $y3 = $this->pdf->textBox(
-                $this->margem,
+            $this->blocoVII_prot(
                 $y+1+$y1+$y2,
-                $this->wPrint,
-                4,
-                $texto,
-                $aFont,
-                'T',
-                'C',
-                false,
-                '',
-                true
-            );
-            
-            $texto = "Data de Autorização:  {$data}";
-            $aFont = ['font'=> $this->fontePadrao, 'size' => (8-$subSize), 'style' => ''];
-            $y4 = $this->pdf->textBox(
-                $this->margem,
-                $y+1+$y1+$y2+$y3,
-                $this->wPrint,
-                4,
-                $texto,
-                $aFont,
-                'T',
-                'C',
-                false,
-                '',
-                true
+                $subSize,
+                $protocolo, 
+                $dhRecbto
             );
         }
         $this->pdf->dashedHLine($this->margem, $this->bloco7H+$y, $this->wPrint, 0.1, 30);
         return $this->bloco7H + $y;
+    }
+
+    protected function blocoVII_prot($y, $subSize, $protocolo, $dhRecbto) {
+        $texto = "Protocolo de Autorização:  {$protocolo}";
+        $aFont = ['font'=> $this->fontePadrao, 'size' => (8-$subSize), 'style' => ''];
+        $y1 = $this->pdf->textBox(
+            $this->margem,
+            $y,
+            $this->wPrint,
+            4,
+            $texto,
+            $aFont,
+            'T',
+            'C',
+            false,
+            '',
+            true
+        );
+        
+        $texto = "Data de Autorização:  {$dhRecbto}";
+        $aFont = ['font'=> $this->fontePadrao, 'size' => (8-$subSize), 'style' => ''];
+        return $this->pdf->textBox(
+            $this->margem,
+            $y+$y1,
+            $this->wPrint,
+            4,
+            $texto,
+            $aFont,
+            'T',
+            'C',
+            false,
+            '',
+            true
+        );
     }
 }


### PR DESCRIPTION
Quando uma nota é emitida em contingência off-line, ela deve ser transmitida o mais rapido possível, mas mesmo depois de transmitida e com numero de protocolo ela mostra "Pendente Autorização", com essa alteração agora vai mostrar o numero de Protocolo e Data que foi autorizada.