### PR TITLE
Fix: timezone Dacte e DacteOS

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -795,8 +795,8 @@ class Dacte extends DaCommon
             'size' => 8,
             'style' => '');
         $this->pdf->textBox($xa, $y + 1, $wa, $h, $texto, $aFont, 'T', 'C', 0, '');
-        $texto = !empty($this->ide->getElementsByTagName("dhEmi")->item(0)->nodeValue) ?
-            date('d/m/Y H:i:s', strtotime($this->getTagValue($this->ide, "dhEmi"))) : '';
+        $dhEmi = $this->toDateTime($this->getTagValue($this->ide, "dhEmi"));
+        $texto = $dhEmi ? $dhEmi->format('d/m/Y H:i:s') : '';
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($xa, $y + 5, $wa, $h, $texto, $aFont, 'T', 'C', 0, '');
         $this->pdf->line($xa + $wa, $y, $xa + $wa, $y + $h + 1);
@@ -879,10 +879,8 @@ class Dacte extends DaCommon
             if (!empty($this->protCTe)
                 && !empty($this->protCTe->getElementsByTagName("dhRecbto")->item(0)->nodeValue)
             ) {
-                $texto .= date(
-                    'd/m/Y   H:i:s',
-                    strtotime($this->getTagValue($this->protCTe, "dhRecbto"))
-                );
+                $dhRecbto = $this->toDateTime($this->getTagValue($this->protCTe, "dhRecbto"));
+                $texto .= $dhRecbto ? $dhRecbto->format('d/m/Y H:i:s') : '';
             }
             $texto = $this->getTagValue($this->protCTe, "nProt") == '' ? '' : $texto;
         }
@@ -1015,14 +1013,15 @@ class Dacte extends DaCommon
                 $infEvento = $retEvento->getElementsByTagName('infEvento')->item(0);
                 $cStat = $this->getTagValue($infEvento, "cStat");
                 $tpEvento = $this->getTagValue($infEvento, "tpEvento");
-                $dhEvento = date("d/m/Y H:i:s", $this->toTimestamp($this->getTagValue($infEvento, "dhRegEvento")));
+                $dhEvento = $this->toDateTime($this->getTagValue($infEvento, "dhRegEvento"));
+                $dhEvento = $dhEvento ? $dhEvento->format('d/m/Y H:i:s') : '';
                 $nProt = $this->getTagValue($infEvento, "nProt");
                 if ($tpEvento == '110111'
                     && ($cStat == '101'
-                    || $cStat == '151'
-                    || $cStat == '135'
-                    || $cStat == '155'
-                )) {
+                        || $cStat == '151'
+                        || $cStat == '135'
+                        || $cStat == '155'
+                    )) {
                     $resp['status'] = false;
                     $resp['message'][] = "CTe CANCELADO";
                     $resp['submessage'] = "{$dhEvento} - {$nProt}";
@@ -2558,11 +2557,15 @@ class Dacte extends DaCommon
             $nDoc = $this->getTagValue($temp, "nDoc");
             $dEmi = $this->getTagValue($temp, "dEmi");
             if (!empty($dEmi)) {
-                $dEmi = "Emissão: " . date('d/m/Y', strtotime($this->getTagValue($temp, "dEmi")));
+                $tempEmi = $this->toDateTime($this->getTagValue($temp, "dEmi"));
+                $tempEmi = $tempEmi ? $tempEmi->format('d/m/Y') : '';
+                $dEmi = "Emissão: " . $tempEmi;
             }
             $vDocFisc = $this->getTagValue($temp, "vDocFisc", "Valor: ");
             $dPrev = $this->getTagValue($temp, "dPrev");
-            $dPrev = !empty($dPrev) ? ("Entrega: " . date('d/m/Y', strtotime($this->getTagValue($temp, "dPrev")))) : '';
+            $datePrev = $this->toDateTime($dPrev);
+            $datePrev = $datePrev ? $datePrev->format('d/m/Y') : '';
+            $dPrev = !empty($dPrev) ? ("Entrega: " . $datePrev) : '';
             switch ($tpDoc) {
                 case "00":
                     $tpDoc = "00 - Declaração";
@@ -3836,3 +3839,4 @@ class Dacte extends DaCommon
         $this->pdf->image($pic, $xQr - 3, $yQr, $wQr, $hQr, 'PNG');
     }
 }
+

--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -624,8 +624,8 @@ class DacteOS extends DaCommon
             'style' => '');
         $this->pdf->textBox($xa, $y + 1, $wa, $h, $texto, $aFont, 'T', 'C', 0, '');
         $this->pdf->line($xa + $wa, $y, $xa + $wa, $y + $h + 1);
-        $texto = !empty($this->ide->getElementsByTagName("dhEmi")->item(0)->nodeValue) ?
-            date('d/m/Y H:i:s', $this->toTimestamp($this->getTagValue($this->ide, "dhEmi"))) : '';
+        $dhEmi = $this->toDateTime($this->getTagValue($this->ide, "dhEmi"));
+        $texto = $dhEmi ? $dhEmi->format('d/m/Y H:i:s') : '';
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($xa, $y + 5, $wa, $h, $texto, $aFont, 'T', 'C', 0, '');
         $this->pdf->line($xa + $wa, $y, $xa + $wa, $y + $h + 1);
@@ -699,10 +699,8 @@ class DacteOS extends DaCommon
             if (!empty($this->protCTe)
                 && !empty($this->protCTe->getElementsByTagName("dhRecbto")->item(0)->nodeValue)
             ) {
-                $texto .= date(
-                    'd/m/Y   H:i:s',
-                    $this->toTimestamp($this->getTagValue($this->protCTe, "dhRecbto"))
-                );
+                $dhRecbto = $this->toDateTime($this->getTagValue($this->protCTe, "dhRecbto"));
+                $texto .= $dhRecbto ? $dhRecbto->format('d/m/Y H:i:s') : '';
             }
             $texto = $this->getTagValue($this->protCTe, "nProt") == '' ? '' : $texto;
         }
@@ -859,14 +857,15 @@ class DacteOS extends DaCommon
                 $infEvento = $retEvento->getElementsByTagName('infEvento')->item(0);
                 $cStat = $this->getTagValue($infEvento, "cStat");
                 $tpEvento = $this->getTagValue($infEvento, "tpEvento");
-                $dhEvento = date("d/m/Y H:i:s", $this->toTimestamp($this->getTagValue($infEvento, "dhRegEvento")));
+                $dhEvento = $this->toDateTime($this->getTagValue($infEvento, "dhRegEvento"));
+                $dhEvento = $dhEvento ? $dhEvento->format('d/m/Y H:i:s') : '';
                 $nProt = $this->getTagValue($infEvento, "nProt");
                 if ($tpEvento == '110111'
                     && ($cStat == '101'
-                    || $cStat == '151'
-                    || $cStat == '135'
-                    || $cStat == '155'
-                )) {
+                        || $cStat == '151'
+                        || $cStat == '135'
+                        || $cStat == '155'
+                    )) {
                     $resp['status'] = false;
                     $resp['message'][] = "CTe CANCELADO";
                     $resp['submessage'] = "{$dhEvento} - {$nProt}";
@@ -1581,7 +1580,7 @@ class DacteOS extends DaCommon
         $texto = !empty($this->getTagValue($this->veic->item(0), "CPF")) ?
             $this->getTagValue($this->veic->item(0), "CPF") :
             (!empty($this->getTagValue($this->veic->item(0), "CNPJ")) ?
-            $this->getTagValue($this->veic->item(0), "CNPJ") : '');
+                $this->getTagValue($this->veic->item(0), "CNPJ") : '');
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($x, $y, $w * $wCol02, $h, $texto, $aFont, 'T', 'L', 0, '');
 
@@ -2240,7 +2239,7 @@ class DacteOS extends DaCommon
     {
         try {
             $fone = !empty($field->getElementsByTagName("fone")->item(0)->nodeValue) ?
-            $field->getElementsByTagName("fone")->item(0)->nodeValue : '';
+                $field->getElementsByTagName("fone")->item(0)->nodeValue : '';
             $foneLen = strlen($fone);
             if ($foneLen > 0) {
                 $fone2 = substr($fone, 0, $foneLen - 4);


### PR DESCRIPTION
Erro ao instanciar data de emissão e protocolo no Dacte/DacteOS devido ao timezone.
Poderíamos setar o timezone antes da geração do documento. Porém, percebi que na geração do documento auxiliar da NF-e se resolveu também desta forma. ex: [NFe/Danfe.php](https://github.com/nfephp-org/sped-da/blob/4fe72ce9628f87a2ee5530e29bc56e6e854c5dc6/src/NFe/Danfe.php#L910)

#### Dacte com divergência na data/hora:
![image](https://user-images.githubusercontent.com/1840969/135908442-63897e8a-0bca-436d-9ccc-2748712b1af7.png)

#### Parte do xml:
![image](https://user-images.githubusercontent.com/1840969/135908520-ad900949-110d-4b70-8cfc-ffd469449b9c.png)

#### Após o ajuste:
![image](https://user-images.githubusercontent.com/1840969/135909468-feddb6f3-db96-45c4-8ea5-c9a4d4fcf834.png)

