### PR TITLE
:bug: Marca d'água

### DIFF
--- a/src/Legacy/Pdf.php
+++ b/src/Legacy/Pdf.php
@@ -884,7 +884,7 @@ class Pdf extends Fpdf
         if ($w < 0) {
             return $y;
         }
-        if (is_object($text) || is_array($text) {
+        if (is_object($text) || is_array($text)) {
             $text = '';
         }
         if (is_string($text)) {


### PR DESCRIPTION
 - quando marca d'água for array, está imprimindo o texto "ARRAY"