### PR TITLE
Correção em DanfeSimples - Erro no campo de transporte

### DIFF
--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -469,7 +469,7 @@ class DanfeSimples extends DaCommon
         $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);
         $this->pdf->cell(($c1 * 4), $pequeno ? 4 : 5, "{$enderecoLinha2}", 1, 1, 'C', 1);
 
-        if ($this->nfeArray['NFe']['infNFe']['transp']['modFrete'] != 9) {
+        if ($this->nfeArray['NFe']['infNFe']['transp']['modFrete'] != 9 && isset($this->nfeArray['NFe']['infNFe']['transp']['transporta']) ) {
             $this->pdf->setFont('Arial', 'B', $pequeno ? 10 : 12);
             $this->pdf->cell(($c1 * 4), $pequeno ? 5 : 6, "TRANSPORTADORA", 1, 1, 'C', 1);
             $this->pdf->setFont('Arial', '', $pequeno ? 9 : 10);


### PR DESCRIPTION
Quando a NFe tinha modFrete !=9, porém sem a tag da transportadora (transporta) preenchida, o script travava ao tentar acessar a tag inexistente para montar o quadro de transporte. Adicionei uma condição a mais para que isso não aconteça.