### PR TITLE
Danfe.php com erro de formatação

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3085,14 +3085,16 @@ class Danfe extends DaCommon
                 $yTrib += $y;
                 $diffH = $hmax - $hUsado;
 
-                if ($pag != $totpag) {
-                    if (1 > $diffH && $i < $totItens) {
+                if (1 > $diffH && $i < $totItens) {
+                    if ($pag == $totpag) {
+                        $totpag++;
+                    }
                         //ultrapassa a capacidade para uma única página
                         //o restante dos dados serão usados nas proximas paginas
                         $nInicio = $i;
                         break;
-                    }
                 }
+                
                 $y_linha = $y + $h;
 
                 //corrige o x


### PR DESCRIPTION
Realocado o if ($pag != $totpag) (linha 3088 no original) que impossibilitava a verificação da quantidade dos itens na última página do Danfe gerado, resultando em um erro de formatação. Agora ele verifica se existem itens de sobra e se é a última página, caso ambos os casos ocorram é incrementada mais uma página ao Danfe com os itens são adicionados. Caso precisem entrar em contato para analisar a alteração, meu e-mail é: [andersonjrignacio@gmail.com](mailto:andersonjrignacio@gmail.com). Obrigado desde já.