### PR TITLE
Flag para exibir o nº do item no pedido de compra

### DIFF
--- a/examples/nfe/danfe.php
+++ b/examples/nfe/danfe.php
@@ -10,13 +10,14 @@ $logo = 'data://text/plain;base64,'. base64_encode(file_get_contents(realpath(__
 //$logo = realpath(__DIR__ . '/../images/tulipas.png');
 
 try {
-    
+
     $danfe = new Danfe($xml);
     $danfe->exibirTextoFatura = false;
     $danfe->exibirPIS = false;
     $danfe->exibirIcmsInterestadual = false;
     $danfe->exibirValorTributos = false;
     $danfe->descProdInfoComplemento = false;
+    $danfe->exibirNumeroItemPedido = false;
     $danfe->setOcultarUnidadeTributavel(true);
     $danfe->obsContShow(false);
     $danfe->printParameters(
@@ -31,7 +32,7 @@ try {
     $danfe->debugMode(false);
     $danfe->creditsIntegratorFooter('WEBNFe Sistemas - http://www.webenf.com.br');
     //$danfe->epec('891180004131899', '14/08/2018 11:24:45'); //marca como autorizada por EPEC
-    
+
     // Caso queira mudar a configuracao padrao de impressao
     /*  $this->printParameters( $orientacao = '', $papel = 'A4', $margSup = 2, $margEsq = 2 ); */
     // Caso queira sempre ocultar a unidade tributável
@@ -46,4 +47,4 @@ try {
     echo $pdf;
 } catch (InvalidArgumentException $e) {
     echo "Ocorreu um erro durante o processamento :" . $e->getMessage();
-}    
+}

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -47,6 +47,13 @@ class Danfe extends DaCommon
      */
     public $exibirTextoFatura = false;
     /**
+     * Parâmetro do controle se deve exibir o número do item no pedido de compra
+     * na descrição do produto
+     *
+     * @var boolean
+     */
+    public $exibirNumeroItemPedido = false;
+    /**
      * Parâmetro do controle se deve concatenar automaticamente informações complementares
      * na descrição do produto, como por exemplo, informações sobre impostos.
      *
@@ -2710,6 +2717,10 @@ class Danfe extends DaCommon
             $texto = str_replace(";", "\n", $texto);
         }
 
+        if ($this->exibirNumeroItemPedido && !empty($itemProd->getElementsByTagName('nItemPed')->item(0)->nodeValue)) {
+            $texto .= " (ITEM " . $itemProd->getElementsByTagName('nItemPed')->item(0)->nodeValue . ")";
+        }
+
         return $texto;
     }
 
@@ -3094,7 +3105,7 @@ class Danfe extends DaCommon
                         $nInicio = $i;
                         break;
                 }
-                
+
                 $y_linha = $y + $h;
 
                 //corrige o x


### PR DESCRIPTION
Flag para mostrar o número do item do pedido de compra na descrição do produto.

![image](https://user-images.githubusercontent.com/6354258/184496888-06cb1a19-1dea-4c03-9e80-0f563510d390.png)
