### PR TITLE
Correções de compatibilidade com PHP 8.2

### DIFF
--- a/src/Legacy/Pdf.php
+++ b/src/Legacy/Pdf.php
@@ -892,7 +892,7 @@ class Pdf extends Fpdf
             //remover espaços desnecessários
             $text = trim($text);
             //converter o charset para o fpdf
-            $text = utf8_decode($text);
+            $text = mb_convert_encoding($text, 'ISO-8859-1');
             //decodifica os caracteres html no xml
             $text = html_entity_decode($text);
         } else {
@@ -1033,7 +1033,7 @@ class Pdf extends Fpdf
             //remover espaços desnecessários
             $text = trim($text);
             //converter o charset para o fpdf
-            $text = utf8_decode($text);
+            $text = mb_convert_encoding($text, 'ISO-8859-1');
             //decodifica os caracteres html no xml
             $text = html_entity_decode($text);
         } else {

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -133,6 +133,18 @@ class Danfe extends DaCommon
      * @var integer
      */
     protected $qtdeItensProc;
+    /*
+     * NF-e processada
+     * 
+     * @var \DOMNode
+     */
+    protected $nfeProc;
+    /*
+     * Grupo de detalhamento da forma de pagamento
+     * 
+     * @var \DOMNode
+     */
+    protected $detPag;
     /**
      * Dom Document
      *


### PR DESCRIPTION
Essa PR visa corrigir os avisos de DEPRECATED encontrados na versão 8.2 do PHP, impedindo a a geração do PDF

> `Deprecated: Function utf8_decode() is deprecated`
> `Deprecated: Creation of dynamic property NFePHP\DA\NFe\Danfe::$nfeProc is deprecated`
> `Deprecated: Creation of dynamic property NFePHP\DA\NFe\Danfe::$detPag is deprecated`