### PR TITLE
Declarar propriedades que eram dinâmicas

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -87,6 +87,17 @@ class Dacte extends DaCommon
     protected $margemInterna = 0;
     protected $formatoChave = "#### #### #### #### #### #### #### #### #### #### ####";
 
+    protected $cteProc;
+    protected $aereo;
+    protected $lota;
+    protected $infOutros;
+    protected $toma;
+    protected $enderToma;
+    protected $protCTe;
+    protected $formatPadrao;
+    protected $wCanhoto;
+    protected $arrayNF;
+
     /**
      * __construct
      *

--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -77,6 +77,18 @@ class DacteOS extends DaCommon
     protected $formatoChave = "#### #### #### #### #### #### #### #### #### #### ####";
     protected $margemInterna = 0;
 
+    protected $infOutros;
+    protected $ICMSSN;
+    protected $toma;
+    protected $enderToma;
+    protected $xSeg;
+    protected $nApol;
+    protected $respSeg;
+    protected $protCTe;
+    protected $qrCodMDFe;
+    protected $cteProc;
+    protected $wCanhoto;
+
     /**
      * __construct
      *

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -43,6 +43,46 @@ class Damdfe extends DaCommon
     protected $tpEmis;
     protected $qrCodMDFe;
     protected $baseFont = array('font' => 'Times', 'size' => 8, 'style' => '');
+    protected $infMDFe;
+    protected $emit;
+    protected $CPF;
+    protected $CNPJ;
+    protected $IE;
+    protected $xNome;
+    protected $enderEmit;
+    protected $xLgr;
+    protected $nro;
+    protected $xBairro;
+    protected $UF;
+    protected $xMun;
+    protected $CEP;
+    protected $mod;
+    protected $serie;
+    protected $dhEmi;
+    protected $UFIni;
+    protected $UFFim;
+    protected $nMDF;
+    protected $tot;
+    protected $qMDFe;
+    protected $qNFe;
+    protected $qNF;
+    protected $qCTe;
+    protected $qCT;
+    protected $qCarga;
+    protected $cUnid;
+    protected $infModal;
+    protected $rodo;
+    protected $aereo;
+    protected $aquav;
+    protected $ferrov;
+    protected $RNTRC;
+    protected $ciot;
+    protected $veicTracao;
+    protected $veicReboque;
+    protected $valePed;
+    protected $infCpl;
+    protected $dhRecbto;
+    protected $condutor;
     /**
      * @var string
      */

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -37,6 +37,7 @@ class Danfce extends DaCommon
     protected $ide;
     protected $enderDest;
     protected $ICMSTot;
+    protected $tpImp;
     protected $imposto;
     protected $emit;
     protected $enderEmit;

--- a/src/NFe/DanfeEtiqueta.php
+++ b/src/NFe/DanfeEtiqueta.php
@@ -33,9 +33,11 @@ class DanfeEtiqueta extends DaCommon
     protected $infAdic;
     protected $infCpl;
     protected $infAdFisco;
+    protected $infProt;
     protected $textoAdic;
     protected $tpEmis;
     protected $tpAmb;
+    protected $tpImp;
     protected $pag;
     protected $vTroco;
     protected $itens = [];


### PR DESCRIPTION
Essa PR visa corrigir o seguinte erro nas versões mais recentes do PHP (>=8.2):

> `Deprecated: Creation of dynamic property $tpImp is deprecated`

Esse erro acontece ao atribuir uma variável da classe sem tê-la declarado