### PR TITLE
Corrigindo erro constante php usando self::

### DIFF
--- a/src/Legacy/FPDF/Fpdf181.php
+++ b/src/Legacy/FPDF/Fpdf181.php
@@ -97,7 +97,7 @@ class Fpdf181
         $this->withAlpha = false;
         $this->ws = 0;
 
-        $this->fontpath = __DIR__. FPDF_FONTPATH;
+        $this->fontpath = __DIR__. self::FPDF_FONTPATH;
 
         // Core fonts
         $this->coreFonts = [
@@ -2056,7 +2056,7 @@ class Fpdf181
 
     protected function putInfo()
     {
-        $this->metadata['Producer'] = 'FPDF ' . FPDF_VERSION;
+        $this->metadata['Producer'] = 'FPDF ' . self::FPDF_VERSION;
         $this->metadata['CreationDate'] = 'D:' . @date('YmdHis');
         foreach ($this->metadata as $key => $value) {
             $this->put('/' . $key . ' ' . $this->textString($value));


### PR DESCRIPTION
Estou migrando o sistema aqui da empresa para PHP 8.x e me deparei com esse erro:

```
Warning: Use of undefined constant FPDF_FONTPATH - assumed 'FPDF_FONTPATH' 
(this will throw an Error in a future version of PHP) 
in /var/www/vendor/nfephp-org/sped-da/src/Legacy/FPDF/Fpdf181.php:100
```

Fiz uma correção simples para resolver o problema.