### PR TITLE
🌐 Corrigindo erros de encoding

### DIFF
--- a/src/Legacy/Pdf.php
+++ b/src/Legacy/Pdf.php
@@ -893,7 +893,7 @@ class Pdf extends Fpdf
             //remover espaços desnecessários
             $text = trim($text);
             //converter o charset para o fpdf
-            $text = mb_convert_encoding($text, 'ISO-8859-1');
+            $text = $this->convertToIso($text);
             //decodifica os caracteres html no xml
             $text = html_entity_decode($text);
         } else {
@@ -1034,7 +1034,7 @@ class Pdf extends Fpdf
             //remover espaços desnecessários
             $text = trim($text);
             //converter o charset para o fpdf
-            $text = mb_convert_encoding($text, 'ISO-8859-1');
+            $text = $this->convertToIso($text);
             //decodifica os caracteres html no xml
             $text = html_entity_decode($text);
         } else {
@@ -1117,4 +1117,15 @@ class Pdf extends Fpdf
         $this->rotate(0, $x, $y);
         return ($y1 - $y) - $incY;
     }
+
+    /**
+     * Converte os caracteres para ISO-88591.
+     *
+     * @param string $text
+     * @return string
+     */
+    private function convertToIso($text) {
+        return mb_convert_encoding($text, 'ISO-8859-1', ['UTF-8', 'windows-1252']);
+    }
+
 }


### PR DESCRIPTION
Baseada na documentação do método `mb_convert_encoding` https://www.php.net/manual/en/function.mb-convert-encoding.php se o terceiro parametro for omitido será utilizada `mbstring.internal_encoding setting` e no meu caso não posso definir ela para UTF-8 pois meu sistema está todo encodificado para ISO-8859-1. Nesse caso passei um array com dois prováveis encodings para que ele possa fazer a conversão corretamente.

Caso exista outro solução melhor ou se isso for impactar outros lugares aceito sugestões, para mim resolveu.