### PR TITLE
Exibir motivo como submessage para status Denegada em  Danfe

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -959,6 +959,7 @@ class Danfe extends DaCommon
             if (in_array($cStat, ['110', '205', '301', '302', '303'])) {
                 $resp['status'] = false;
                 $resp['message'][] = "NFe DENEGADA";
+                $resp['submessage'] = $this->infProt->getElementsByTagName('xMotivo')->item(0)->nodeValue;
             } elseif (in_array($cStat, ['101', '151', '135', '155'])
                 || $this->cancelFlag === true
             ) {


### PR DESCRIPTION
Não está sendo exibido o motivo de Danfe com status Denegada, e essa informação tem muito valor para o cliente.

Em uma versão mais antiga que estávamos usando, essa informação existia conforme a print abaixo:

<img width="679" alt="Captura de Tela 2023-11-17 às 14 33 41" src="https://github.com/nfephp-org/sped-da/assets/7474249/feda8d8f-c41b-4040-a86d-f7d86203f615">
