### PR TITLE
Altera a descrição da forma 05 Cartão da loja adicionando "Outros Crediários"

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2134,7 +2134,7 @@ class Danfe extends DaCommon
                 '02' => 'Cheque',
                 '03' => 'Cartão de Crédito',
                 '04' => 'Cartão de Débito',
-                '05' => 'Cartão da Loja',
+                '05' => 'Cartão da Loja/Outros Crediários',
                 '10' => 'Vale Alimentação',
                 '11' => 'Vale Refeição',
                 '12' => 'Vale Presente',


### PR DESCRIPTION
Altera a descrição da forma 05 Cartão da loja adicionando "Outros Crediários" para ficar compatível com o passado e também com a planilha da SEFAZ:

Cartão da Loja (Private Label), Crediário Digital, Outros Crediários 	 Descrição:
"Cartão da loja (na forma de crediário), Crediário Digital, Crediário com ou sem Carnê etc.  Não usar para o cartão de loja ""bandeirado""."

[Tabela de Meios de Pagamento - Vigente a partir de 01/07/2024 - Publicada em 07/06/2024](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=nB7L5ty6geI=)
Tabela dos códigos de meios de pagamento

[Tabela_de_meios_de_pagamento - 03062024.xlsx](https://github.com/user-attachments/files/16097763/Tabela_de_meios_de_pagamento.-.03062024.xlsx)
