### PR TITLE
Corrige validação ao gerar MDF-e quando RNTRC não é obrigatório #576

### DIFF
--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -168,8 +168,10 @@ class Damdfe extends DaCommon
             if (!empty($this->rodo)) {
                 $this->RNTRC = "";
                 $infANTT = $this->rodo->getElementsByTagName("infANTT")->item(0);
-                if (!empty($infANTT) && isset($infANTT->getElementsByTagName("RNTRC")->item(0)->nodeValue)) {
-                    $this->RNTRC = $infANTT->getElementsByTagName("RNTRC")->item(0)->nodeValue;
+                if(isset($infANTT)){
+                    if (isset($infANTT->getElementsByTagName("RNTRC")->item(0)->nodeValue)) {
+                        $this->RNTRC = $infANTT->getElementsByTagName("RNTRC")->item(0)->nodeValue;
+                    }
                 }
             }
             $this->ciot = "";


### PR DESCRIPTION
Adicionada uma verificação adicional para garantir que a tag infANTT esteja definida antes de tentar acessar RNTRC. Verificado se RNTRC está presente dentro de infANTT antes de acessar seu valor, prevenindo assim a exceção.