### PR TITLE
Ajusta referência à DANFe no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Ou ainda alterando o composer.json do seu aplicativo inserindo:
 ```
 
 ## Forma de uso
-[DANFE](docs/DANFE.md)
+- [DANFE](docs/Danfe2.md)
+- [DACTE](docs/Dacte.md)
 
 ## Log de mudanças e versões
 Acompanhe o [CHANGELOG](CHANGELOG.md) para maiores informações sobre as alterações recentes.

--- a/docs/Dacte.md
+++ b/docs/Dacte.md
@@ -76,7 +76,7 @@ Esse método estabelece os parametros de impressão do PDF, forçando essas opç
 
 ```php
 $da->printParameters('P', 'A4', 2, 2);
-``
+```
 
 ### public depecNumber($numdepec)
 
@@ -86,7 +86,7 @@ Esse metodo permite passar o número do DPEC na emissão em contigência DPEC, p
 
 ```php
 $da->depecNumber('12345678');
-``
+```
 
 ### public render($logo = null)
 

--- a/docs/Danfe.md
+++ b/docs/Danfe.md
@@ -10,9 +10,10 @@ Nele também consta o número de protocolo no registro na integração junto ao 
 ### function __construct()
 Método construtor. Instancia a classe
 
-    ```php
-    $danfe = new Danfe([String xml]);
-    ``` 
+```php
+$danfe = new Danfe([String xml]);
+```
+
 ### function render()
 Método de rederização do PDF
 

--- a/docs/Danfe2.md
+++ b/docs/Danfe2.md
@@ -117,11 +117,6 @@ Todos esses métodos são opcionais caso queira alterar o comportamento padrão 
      * @return void
      */
     $danfe2->exibirNumeroItem(false); //default true
-    
-    
-
-    
-
 ```
 
 ## Elementos Adicionais
@@ -179,10 +174,7 @@ São métodos que incluem informações ao DANFE.
 ## Exemplo
 
 ```php
-
-
 try {
-
     //dados
     $xml = file_get_contents(__DI__.'/arquivo_xml_nfe_modelo_55.xml');
     $logo = 'data://text/plain;base64,'. base64_encode(file_get_contents(__DIR__ . '/tulipas.png'));


### PR DESCRIPTION
O link para a documentação do documento auxiliar de NFe estava quebrado, ou seja, não estava levando à documentação correta.

Para a correção, foi feito o ajuste da referência para a documentação da DANFe, também foi adicionada referência para DACTe.

Por fim, alguns ajustes na documentação referentes à citações de códigos.