### PR TITLE
feat: adicionando código de regime tributário 4 - Simples Nacional - Microempreendedor Individual MEI

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -3024,10 +3024,10 @@ class Danfe extends DaCommon
         //O/CST ou O/CSOSN
         $x     += $w3;
         $w4    = round($w * 0.05, 0);
-        $texto = 'O/CST'; // CRT = 2 ou CRT = 3
-        if ($this->getTagValue($this->emit, 'CRT') == '1') {
-            $texto = 'O/CSOSN'; //Regime do Simples CRT = 1
-        }
+        $crt = $this->getTagValue($this->emit, 'CRT');
+        // 1=Simples Nacional; 2=Simples Nacional, excesso sublimite de receita bruta;
+        // 3=Regime Normal; 4=Simples Nacional - Microempreendedor Individual - MEI;
+        $texto = in_array($crt, ['1', '4']) ? 'O/CSOSN' : 'O/CST';
         $aFont = ['font' => $this->fontePadrao, 'size' => 6, 'style' => ''];
         $this->pdf->textBox($x, $y, $w4, $h, $texto, $aFont, 'C', 'C', 0, '', false);
         //$this->pdf->line($x + $w4, $y, $x + $w4, $y + $hmax);


### PR DESCRIPTION
Adicionando código de regime tributário (4) - Simples Nacional - Microempreendedor Individual MEI, conforme a versão 1.10 da Nota Técnica 2024.001, publicada pela Sefaz.

**Documentos base**
- https://noticias.iob.com.br/nota-fiscal-mei-crt/
- [NT2024.001-CRT-MEI.pdf](https://github.com/user-attachments/files/17382687/NT2024.001-CRT-MEI.pdf)


![345811450-775bce98-8211-4d36-9d9a-92ad643c2954](https://github.com/user-attachments/assets/1793dd53-208a-467b-bb50-44c09068e837)

