### PR TITLE
Ajustes entidades HTML - PHP 7.4.x

### DIFF
--- a/src/Legacy/Common.php
+++ b/src/Legacy/Common.php
@@ -24,7 +24,7 @@ class Common
             $value = trim($vct->nodeValue);
             if (strpos($value, '&') !== false) {
                 //existe um & na string, então deve ser uma entidade
-                $value = html_entity_decode($value);
+                $value = html_entity_decode($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
             }
             return $extraTextBefore . $value . $extraTextAfter;
         }


### PR DESCRIPTION
Adicionadas flags padrão do PHP 8.1 na chamada da função html_entity_decode, pois a mesma não converte as entidades HTML corretamente quando utilizada no PHP 7.4.x