### PR TITLE
fix: Datetime error format.

### DIFF
--- a/src/Legacy/Common.php
+++ b/src/Legacy/Common.php
@@ -4,7 +4,6 @@ namespace NFePHP\DA\Legacy;
 
 class Common
 {
-
     /**
      * Extrai o valor do node DOM
      * @param  object $theObj Instancia de DOMDocument ou DOMElement
@@ -123,14 +122,34 @@ class Common
      *
      * @param string $input
      *
-     * @return \DateTime
+     * @return \DateTime|false
      */
     public function toDateTime($input)
     {
+        if (PHP_MAJOR_VERSION > 7) {
+            try {
+                return new \DateTime($input);
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return $this->toDateTimeLegacy($input);
+    }
+
+    private function toDateTimeLegacy($input)
+    {
+        $quantidadeColons = substr_count($input, ':');
+
+        $format = "Y-m-d\TH:i:sP";
+        if ($quantidadeColons == 2) {
+            $format = "Y-m-d\TH:i:s";
+        }
+
         try {
-            return \DateTime::createFromFormat("Y-m-d\TH:i:sP", $input);
+            return \DateTime::createFromFormat($format, $input);
         } catch (\Exception $e) {
-            return null;
+            return false;
         }
     }
 

--- a/tests/Legacy/CommonTest.php
+++ b/tests/Legacy/CommonTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NFePHP\DA\Tests\Legacy;
+
+use NFePHP\DA\Legacy\Common;
+use PHPUnit\Framework\TestCase;
+
+class CommonTest extends TestCase
+{
+    private $common;
+
+    protected function setUp(): void
+    {
+        $this->common = new Common();
+    }
+
+    public function testToTimestamp()
+    {
+        $expected = (new \DateTime('2009-11-02T00:00:00-03:00'))->getTimestamp();
+        $this->assertEquals($expected, $this->common->toTimestamp('2009-11-02T00:00:00-03:00'));
+        $this->assertEquals(0, $this->common->toTimestamp('invalid-date'));
+    }
+
+    public function testToDateTime()
+    {
+        $date = $this->common->toDateTime('2009-11-02T00:00:00-03:00');
+        $this->assertInstanceOf(\DateTime::class, $date);
+        $this->assertEquals('2009-11-02', $date->format('Y-m-d'));
+
+        $this->assertFalse($this->common->toDateTime('invalid-date'));
+    }
+
+    public function testToDateTimeWithoutTimezone()
+    {
+        $date = $this->common->toDateTime('2009-11-02T00:00:00');
+        $this->assertInstanceOf(\DateTime::class, $date);
+        $this->assertEquals('2009-11-02', $date->format('Y-m-d'));
+
+        $this->assertFalse($this->common->toDateTime('invalid-date'));
+    }
+
+    public function testToDateTimeLegacy()
+    {
+        $reflection = new \ReflectionClass($this->common);
+        $method = $reflection->getMethod('toDateTimeLegacy');
+        $method->setAccessible(true);
+        $date = $method->invoke($this->common, '2009-11-02T00:00:00');
+        $this->assertInstanceOf(\DateTime::class, $date);
+        $this->assertEquals('2009-11-02', $date->format('Y-m-d'));
+
+        $date = $method->invoke($this->common, '2009-11-02T00:00:00-03:00');
+        $this->assertEquals('2009-11-02', $date->format('Y-m-d'));
+
+        $date = $method->invoke($this->common, 'invalid-date');
+        $this->assertFalse($date);
+    }
+
+}


### PR DESCRIPTION
Alterado metodo para conseguir tratar tanto datetime com timezone, quanto datetime sem timezone.

Motivação:
Tenho algumas danfe`s de entrada antigas que o formatado da resposta do protocolo vem sem timezone, e isso esta quebrando e nao gera a danfe.

Como o Datetime teve uma mudança de comportamento da versão 5 para a 7, fiz uma private funcion para tratar esse caso enquanto ainda é suportado no projeto.

```xml
   <protNFe versao="2.00">
        <infProt Id="xxxxxxxxx">
            <tpAmb>1</tpAmb>
            <verAplic>xxxx</verAplic>
            <chNFe>xxxxxx</chNFe>
            <dhRecbto>2014-09-30T09:46:21</dhRecbto>
            <nProt>xxx</nProt>
            <digVal>xxxx=</digVal>
            <cStat>100</cStat>
            <xMotivo>Autorizado o uso da NF-e</xMotivo>
        </infProt>
    </protNFe>
```

```xml
 <protNFe versao="4.00">
        <infProt>
            <tpAmb>1</tpAmb>
            <verAplic>xxxx</verAplic>
            <chNFe>xxxx</chNFe>
            <dhRecbto>2025-03-25T14:21:17-03:00</dhRecbto>
            <nProt>xxx</nProt>
            <digVal>xxxx</digVal>
            <cStat>100</cStat>
            <xMotivo>Autorizado o uso da NF-e</xMotivo>
        </infProt>
    </protNFe>
```

```bash
/var/www/html/vendor/nfephp-org/sped-da/src/NFe/Danfe.php 1212
["Call to a member function format() on bool"]

#0 /var/www/html/vendor/nfephp-org/sped-da/src/NFe/Danfe.php(630): NFePHP\DA\NFe\Danfe->header()
#1 /var/www/html/vendor/nfephp-org/sped-da/src/Common/DaCommon.php(215): NFePHP\DA\NFe\Danfe->monta()
```