### PR TITLE
Ajustada formatação de telefones Danfe Etiqueta

### DIFF
--- a/src/NFe/DanfeEtiqueta.php
+++ b/src/NFe/DanfeEtiqueta.php
@@ -250,11 +250,8 @@ class DanfeEtiqueta extends DaCommon
         $emitUF = $this->getTagValue($this->enderEmit, "UF");
         $emitFone = $this->getTagValue($this->enderEmit, "fone");
         if (strlen($emitFone) > 0) {
-            if (strlen($emitFone) == 11) {
-                $emitFone = $this->formatField($emitFone, "(##) #####-####");
-            } else {
-                $emitFone = $this->formatField($emitFone, "(##) ####-####");
-            }
+            $format = strlen($emitFone) >= 11 ? "(##) #####-####" : "(##) ####-####";
+            $emitFone = $this->formatField($emitFone, $format);
         }
         $h = 20;
         $maxHimg = $h-2;
@@ -376,11 +373,8 @@ class DanfeEtiqueta extends DaCommon
         $destFone = $this->getTagValue($this->enderDest, "fone");
         $destCep = $this->getTagValue($this->enderDest, "CEP");
         if (strlen($destFone) > 0) {
-            if (strlen($destFone) == 11) {
-                $emitFone = $this->formatField($destFone, "(##) #####-####");
-            } else {
-                $emitFone = $this->formatField($destFone, "(##) ####-####");
-            }
+            $format = strlen($destFone) >= 11 ? "(##) #####-####" : "(##) ####-####";
+            $destFone = $this->formatField($destFone, $format);
         }
         $aFont = ['font' => $this->fontePadrao, 'size' => 10, 'style' => ''];
         $texto = "{$destLgr}, {$destNro} - CEP: {$destCep}";


### PR DESCRIPTION
Realizei um pequeno ajuste na formatação de telefone para destinatário e emitente na impressão de etiqueta

Os telefones que tinham mais de 11 caracteres (geralmente por conter o DDI) não estavam aplicando a formatação corretamente

O telefone para destinatario estava formatando e guardando a formatação na variável errada, no fim era impresso sem a formatação

Antes
```php
$emitFone = $this->getTagValue($this->enderEmit, "fone");
if (strlen($emitFone) > 0) {
    if (strlen($emitFone) == 11) {
        $emitFone = $this->formatField($emitFone, "(##) #####-####");
    } else {
        $emitFone = $this->formatField($emitFone, "(##) ####-####");
    }
}
```

Depois
```php
if (strlen($emitFone) > 0) {
    $format = strlen($emitFone) >= 11 ? "(##) #####-####" : "(##) ####-####";
    $emitFone = $this->formatField($emitFone, $format);
}
```

Antes
```php
if (strlen($destFone) > 0) {
    if (strlen($destFone) == 11) {
        $emitFone = $this->formatField($destFone, "(##) #####-####");
    } else {
        $emitFone = $this->formatField($destFone, "(##) ####-####");
    }
}
```

Depois
```php
if (strlen($destFone) > 0) {
    $format = strlen($destFone) >= 11 ? "(##) #####-####" : "(##) ####-####";
    $destFone = $this->formatField($destFone, $format);
}
```

Antes
![image](https://github.com/user-attachments/assets/bcf77934-7faa-441a-b7f7-f74389a6a7ed)

Depois
![image](https://github.com/user-attachments/assets/d66920b9-b63a-42d6-b533-d0124a2512cc)

