### PR TITLE
Corrige um erro específico de algumas versões de php

### DIFF
--- a/src/Common/DaCommon.php
+++ b/src/Common/DaCommon.php
@@ -300,7 +300,7 @@ class DaCommon extends Common
             throw new \Exception('O formato da imagem não é aceitável! Somente PNG ou JPG podem ser usados.');
         }
         if ($type == '3') { //3 = PNG
-            $image = imagecreatefrompng($logo);
+            $image = @imagecreatefrompng($logo);
             if (!$image) {
                 return null;
             }


### PR DESCRIPTION
o erro que está acontecendo é:
[2025-07-16 09:22:42] production.ERROR: imagecreatefrompng(): gd-png: libpng warning: iCCP: known incorrect sRGB profile {"exception":"[object] (ErrorException(code: 0): imagecreatefrompng(): gd-png: libpng warning: iCCP: known incorrect sRGB profile at /var/www/html/vendor/nfephp-org/sped-da/src/Common/DaCommon.php:303)

Este warning ocorre porque o libpng (a partir da versão 1.6) valida de forma mais rígida o chunk de perfil de cor iCCP nos arquivos PNG e emite o aviso quando encontra um perfil sRGB incorreto ou malformado 

Para muitos usuários, a solução simples é remover esse chunk inválido usando ferramentas como ImageMagick ou pngcrush (ou seja, teria que passar a imagem por um editor para reconfigurar o arquivo mas o arquivo funciona, abre, porem nao está 100% nos padrões aceitos por essa versão dessa lib), ou então suprimir o aviso no PHP (com o operador @ ou ajustando error_reporting)

a solução de adicionar o @ resolve 100% o problema sem maiores transtornos
se puderem aceitar agradeço muito ;-)