### PR TITLE
Add font size customization options

### DIFF
--- a/docs/Danfe.md
+++ b/docs/Danfe.md
@@ -20,3 +20,22 @@ Método de rederização do PDF
 $pdf = $danfe->render();
 ```
 retorna um PDF codificado.
+
+### Personalizacao dos tamanhos de fonte
+Os tamanhos de fonte podem ser ajustados antes da renderizacao do PDF.
+
+```php
+$danfe = new Danfe($xml);
+
+// Reduz todos os tamanhos de fonte em 10%, mantendo no minimo 4 pontos.
+$danfe->setFontSizeScale(0.9, 4);
+
+// Opcionalmente substitui tamanhos especificos.
+$danfe->setFontSizeMap([
+    10 => 9,
+    8 => 7,
+    '5.7' => 5,
+]);
+
+$pdf = $danfe->render();
+```

--- a/src/BPe/Dabpe.php
+++ b/src/BPe/Dabpe.php
@@ -352,6 +352,7 @@ class Dabpe extends DaCommon
         $this->orientacao = 'P';
         $this->papel = [$this->paperwidth, $tamPapelVert];
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
 
         //margens do PDF, em milímetros. Obs.: a margem direita é sempre igual à
         //margem esquerda. A margem inferior *não* existe na FPDF, é definida aqui

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -249,6 +249,7 @@ class Dacte extends DaCommon
         }
         //instancia a classe pdf
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         // verifica se foi passa a fonte a ser usada
         $this->formatPadrao = array(
             'font' => $this->fontePadrao,

--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -222,6 +222,7 @@ class DacteOS extends DaCommon
         $margDir = $this->margesq;
 
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         $this->formatPadrao = array(
             'font' => $this->fontePadrao,
             'size' => 6,

--- a/src/CTe/Daevento.php
+++ b/src/CTe/Daevento.php
@@ -129,6 +129,7 @@ class Daevento extends DaCommon
         $margEsq = $this->margesq;
         $margDir = $this->margesq;
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         if ($this->orientacao == 'P') {
             // posição inicial do relatorio
             $xInic = 1;

--- a/src/Common/DaCommon.php
+++ b/src/Common/DaCommon.php
@@ -14,6 +14,7 @@ namespace NFePHP\DA\Common;
  */
 
 use NFePHP\DA\Legacy\Common;
+use NFePHP\DA\Legacy\Pdf;
 
 class DaCommon extends Common
 {
@@ -73,6 +74,18 @@ class DaCommon extends Common
      * @var array
      */
     protected $aFont = ['font' => 'times', 'size' => 8, 'style' => ''];
+    /**
+     * @var float
+     */
+    protected $fontSizeScale = 1.0;
+    /**
+     * @var array
+     */
+    protected $fontSizeMap = [];
+    /**
+     * @var float|null
+     */
+    protected $minimumFontSize = null;
     /**
      * @var string
      */
@@ -245,6 +258,35 @@ class DaCommon extends Common
     }
 
     /**
+     * Seta a escala aplicada aos tamanhos de fonte do documento.
+     * @param float $scale
+     * @param float|null $minimumSize
+     * @return void
+     */
+    public function setFontSizeScale($scale = 1.0, $minimumSize = null)
+    {
+        $scale = (float) $scale;
+        if ($scale <= 0) {
+            $scale = 1.0;
+        }
+        $this->fontSizeScale = $scale;
+        $this->minimumFontSize = $minimumSize === null ? null : max((float) $minimumSize, 0.1);
+        $this->applyPdfFontSettings();
+    }
+
+    /**
+     * Seta substituicoes de tamanhos de fonte.
+     * Ex.: [10 => 9, 8 => 7, '5.7' => 5]
+     * @param array $fontSizeMap
+     * @return void
+     */
+    public function setFontSizeMap(array $fontSizeMap = [])
+    {
+        $this->fontSizeMap = $fontSizeMap;
+        $this->applyPdfFontSettings();
+    }
+
+    /**
      * Seta o numero de casas decimais a serem usadas como padrão
      * @param int $dec
      */
@@ -266,6 +308,20 @@ class DaCommon extends Common
     protected function monta($logo = null)
     {
         //todo replaced in other classes
+    }
+
+    /**
+     * Aplica as configuracoes de fonte ao PDF atual.
+     * @return void
+     */
+    protected function applyPdfFontSettings(?Pdf $pdf = null)
+    {
+        $pdf = $pdf ?? $this->pdf;
+        if (!$pdf instanceof Pdf) {
+            return;
+        }
+        $pdf->setFontSizeScale($this->fontSizeScale, $this->minimumFontSize);
+        $pdf->setFontSizeMap($this->fontSizeMap);
     }
 
     /**

--- a/src/Legacy/Pdf.php
+++ b/src/Legacy/Pdf.php
@@ -16,6 +16,18 @@ class Pdf extends Fpdf
     private $jStart = ["A"=> 103, "B"=> 104, "C" => 105];      // Caracteres de seleção do grupo 128
     private $jSwap = ["A" => 101, "B" => 100, "C" => 99];      // Caracteres de troca de grupo
     private $angle = 0;
+    /**
+     * @var float
+     */
+    private $fontSizeScale = 1.0;
+    /**
+     * @var array
+     */
+    private $fontSizeMap = [];
+    /**
+     * @var float|null
+     */
+    private $minimumFontSize = null;
 
     public function __construct($orientation = 'P', $unit = 'mm', $format = 'A4')
     {
@@ -162,6 +174,52 @@ class Pdf extends Fpdf
     }
 
     /**
+     * Define a escala aplicada aos tamanhos de fonte do PDF.
+     * @param float $scale
+     * @param float|null $minimumSize
+     * @return void
+     */
+    public function setFontSizeScale($scale = 1.0, $minimumSize = null)
+    {
+        $scale = (float) $scale;
+        if ($scale <= 0) {
+            $scale = 1.0;
+        }
+        $this->fontSizeScale = $scale;
+        $this->minimumFontSize = $minimumSize === null ? null : max((float) $minimumSize, 0.1);
+    }
+
+    /**
+     * Define tamanhos especificos para substituir os tamanhos originais.
+     * @param array $fontSizeMap
+     * @return void
+     */
+    public function setFontSizeMap(array $fontSizeMap = [])
+    {
+        $this->fontSizeMap = [];
+        foreach ($fontSizeMap as $originalSize => $newSize) {
+            if (!is_numeric($originalSize) || !is_numeric($newSize)) {
+                continue;
+            }
+            $newSize = (float) $newSize;
+            if ($newSize <= 0) {
+                continue;
+            }
+            $this->fontSizeMap[$this->fontSizeKey($originalSize)] = $newSize;
+        }
+    }
+
+    public function setFont($family, $style = '', $size = 0)
+    {
+        parent::setFont($family, $style, $this->normalizeFontSize($size));
+    }
+
+    public function setFontSize($size)
+    {
+        parent::setFontSize($this->normalizeFontSize($size));
+    }
+
+    /**
      * Imprime barcode 128
      */
     public function code128($x, $y, $code, $w, $h)
@@ -233,6 +291,37 @@ class Pdf extends Fpdf
                 $x += ($c[$j++]+$c[$j])*$modul;
             }
         }
+    }
+
+    /**
+     * @param int|float|string $size
+     * @return int|float|string
+     */
+    private function normalizeFontSize($size)
+    {
+        if (!is_numeric($size) || (float) $size <= 0) {
+            return $size;
+        }
+        $fontSize = (float) $size;
+        $key = $this->fontSizeKey($fontSize);
+        if (array_key_exists($key, $this->fontSizeMap)) {
+            $fontSize = $this->fontSizeMap[$key];
+        } else {
+            $fontSize *= $this->fontSizeScale;
+        }
+        if ($this->minimumFontSize !== null) {
+            $fontSize = max($fontSize, $this->minimumFontSize);
+        }
+        return $fontSize;
+    }
+
+    /**
+     * @param int|float|string $size
+     * @return string
+     */
+    private function fontSizeKey($size)
+    {
+        return rtrim(rtrim(sprintf('%.4F', (float) $size), '0'), '.');
     }
 
     /**

--- a/src/MDFe/Daevento.php
+++ b/src/MDFe/Daevento.php
@@ -125,6 +125,7 @@ class Daevento extends DaCommon
         $margEsq = $this->margesq;
         $margDir = $this->margesq;
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         if ($this->orientacao == 'P') {
             // posição inicial do relatorio
             $xInic = 1;

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -228,6 +228,7 @@ class Damdfe extends DaCommon
     public function buildMDFe()
     {
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         if ($this->orientacao == 'P') {
             // margens do PDF
             $margSup = 7;

--- a/src/NFSe/Danfse.php
+++ b/src/NFSe/Danfse.php
@@ -136,6 +136,7 @@ class Danfse extends DaCommon
         }
 
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         $this->pdf->aliasNbPages();
         $this->pdf->setMargins(self::PAGE_MARGIN, self::PAGE_MARGIN);
         $this->pdf->setAutoPageBreak(false);

--- a/src/NFe/Daevento.php
+++ b/src/NFe/Daevento.php
@@ -162,6 +162,7 @@ class Daevento extends DaCommon
             $this->orientacao = 'P';
         }
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         if ($this->orientacao == 'P') {
             // margens do PDF
             $margSup = 2;

--- a/src/NFe/Danfce.php
+++ b/src/NFe/Danfce.php
@@ -220,6 +220,7 @@ class Danfce extends DaCommon
         $this->papel = [$this->paperwidth, $tamPapelVert];
         $this->logoAlign = 'L';
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
 
         //margens do PDF, em milímetros. Obs.: a margem direita é sempre igual à
         //margem esquerda. A margem inferior *não* existe na FPDF, é definida aqui

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -513,6 +513,7 @@ class Danfe extends DaCommon
         }
         //instancia a classe pdf
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         //margens do PDF, em milímetros. Obs.: a margem direita é sempre igual à
         //margem esquerda. A margem inferior *não* existe na FPDF, é definida aqui
         //apenas para controle se necessário ser maior do que a margem superior

--- a/src/NFe/DanfeEtiqueta.php
+++ b/src/NFe/DanfeEtiqueta.php
@@ -168,6 +168,7 @@ class DanfeEtiqueta extends DaCommon
         $this->papel = [$this->paperwidth, $this->paperlength];
         $this->logoAlign = 'L';
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         $this->pdf->aliasNbPages();
         $this->pdf->setMargins($margEsq, $margSup); // fixa as margens
         $this->pdf->setDrawColor(0, 0, 0);

--- a/src/NFe/DanfeSimples.php
+++ b/src/NFe/DanfeSimples.php
@@ -217,6 +217,7 @@ class DanfeSimples extends DaCommon
             $this->orientacao = 'L';
         }
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         if ($this->orientacao == 'L') {
             if ($this->papel == 'A5') {
                 $this->maxW = 210;

--- a/src/NFe/DanfeVarejo.php
+++ b/src/NFe/DanfeVarejo.php
@@ -194,6 +194,7 @@ class DanfeVarejo extends DaCommon
         $this->papel = [$this->paperwidth, $this->paperlength];
         $this->logoAlign = 'L';
         $this->pdf = new Pdf($this->orientacao, 'mm', $this->papel);
+        $this->applyPdfFontSettings();
         $this->pdf->aliasNbPages();
         $this->pdf->setMargins($margEsq, $margSup); // fixa as margens
         $this->pdf->setDrawColor(0, 0, 0);

--- a/src/NFe/Traits/TraitBlocoIX.php
+++ b/src/NFe/Traits/TraitBlocoIX.php
@@ -60,6 +60,7 @@ trait TraitBlocoIX
         $wprint = $this->paperwidth - (2 * $this->margem);
         $orientacao = 'P';
         $pdf = new Pdf($orientacao, 'mm', $papel);
+        $this->applyPdfFontSettings($pdf);
         $fsize = 7;
         $aFont = ['font'=> $this->fontePadrao, 'size' => 7, 'style' => ''];
         if ($this->paperwidth < 70) {

--- a/tests/Legacy/PdfFontSizeTest.php
+++ b/tests/Legacy/PdfFontSizeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NFePHP\DA\Tests\Legacy;
+
+use NFePHP\DA\Legacy\Pdf;
+use PHPUnit\Framework\TestCase;
+
+class PdfFontSizeTest extends TestCase
+{
+    public function testAplicaEscalaAoTamanhoDaFonte(): void
+    {
+        $pdf = new Pdf();
+        $pdf->setFontSizeScale(0.8);
+
+        $pdf->setFont('times', '', 10);
+
+        $this->assertSame(8.0, $pdf->fontSizePt);
+    }
+
+    public function testAplicaTamanhoMinimoDeFonte(): void
+    {
+        $pdf = new Pdf();
+        $pdf->setFontSizeScale(0.5, 6);
+
+        $pdf->setFont('times', '', 8);
+
+        $this->assertSame(6.0, $pdf->fontSizePt);
+    }
+
+    public function testSubstituiTamanhoDaFontePorMapa(): void
+    {
+        $pdf = new Pdf();
+        $pdf->setFontSizeMap([
+            10 => 9,
+            '5.7' => 5,
+        ]);
+
+        $pdf->setFont('times', '', 10);
+        $this->assertSame(9.0, $pdf->fontSizePt);
+
+        $pdf->setFont('times', '', 5.7);
+        $this->assertSame(5.0, $pdf->fontSizePt);
+    }
+}

--- a/tests/NFe/DanfeTest.php
+++ b/tests/NFe/DanfeTest.php
@@ -15,4 +15,19 @@ class DanfeTest extends TestCase
         file_put_contents(TEST_FIXTURES . 'pdf/nfe_linhas.pdf', $pdf);
         $this->assertIsString($pdf);
     }
+
+    public function testGerarNfeComTamanhosDeFonteCustomizados(): void
+    {
+        $obj = new Danfe(file_get_contents(TEST_FIXTURES . 'xml/nfe.xml'));
+        $obj->setFontSizeScale(0.9, 4);
+        $obj->setFontSizeMap([
+            10 => 9,
+            8 => 7,
+            '5.7' => 5,
+        ]);
+
+        $pdf = $obj->render();
+
+        $this->assertIsString($pdf);
+    }
 }


### PR DESCRIPTION
## Summary
- Add global font size scaling support to the shared PDF renderer.
- Add exact font size replacements through a font size map.
- Expose the configuration through `DaCommon` and apply it when auxiliary documents create their internal PDF instances.
- Document DANFE usage and add tests for PDF font sizing and DANFE rendering with customized font sizes.

## Usage

    $danfe = new Danfe($xml);
    $danfe->setFontSizeScale(0.9, 4);
    $danfe->setFontSizeMap([
        10 => 9,
        8 => 7,
        '5.7' => 5,
    ]);
    $pdf = $danfe->render();

## Tests
- `vendor/bin/phpunit --filter 'PdfFontSizeTest|DanfeTest'`
- `php -l src/Common/DaCommon.php && php -l src/Legacy/Pdf.php && php -l src/NFe/Danfe.php && php -l src/NFe/Traits/TraitBlocoIX.php`

Note: running `composer test` locally with PHP 8.4 currently fails in `NFePHP\DA\Tests\NFSe\DanfseTest::testUsaIbscbsConsolidadoDaInfNfseQuandoInformado` because the generated text contains `Base de Cálculo Após Exclusões e Reduções R$ 985,00` while the test expects `R$ 777,77`. This failure is outside the font customization changes.
