### PR TITLE
Corrige campo "Nome / Nome Empresarial" da área "PRESTADOR / FORNECEDOR" quando o Prestador é o Emitente da DPS

### DIFF
--- a/src/NFSe/Danfse.php
+++ b/src/NFSe/Danfse.php
@@ -396,6 +396,14 @@ class Danfse extends DaCommon
         }
 
         $end = $this->childNode('end', $node);
+
+        $tpEmit = $this->tpEmit($this->value('tpEmit', $this->infDPS));
+        if ($title === "PRESTADOR / FORNECEDOR" && $node->tagName === "prest" && $tpEmit === "Prestador") {
+            $nome = $this->value('xNome', $this->firstNode('emit', $this->infNFSe));
+        } else {
+            $nome = $this->value('xNome', $node);
+        }
+
         $this->drawSectionTitle($title, self::X, $y, self::CELL, self::ROW);
         $this->drawField('CNPJ / CPF / NIF', $this->document($node), self::COL2, $y, self::CELL, self::ROW);
         if ($withIm) {
@@ -403,7 +411,7 @@ class Danfse extends DaCommon
         }
         $this->drawField('Telefone', $this->formatPhone($this->value('fone', $node)), self::COL4, $y, self::CELL, self::ROW);
 
-        $this->drawField('Nome / Nome Empresarial', $this->ellipsis($this->value('xNome', $node), 80), self::X, $y + 6.4, self::CELL2, self::ROW);
+        $this->drawField('Nome / Nome Empresarial', $this->ellipsis($nome, 80), self::X, $y + 6.4, self::CELL2, self::ROW);
         $this->drawField('Município / Sigla UF', $this->municipioUf($end), self::COL3, $y + 6.4, self::CELL, self::ROW);
         $this->drawField('Código IBGE / CEP', $this->ibgeCep($end), self::COL4, $y + 6.4, self::CELL, self::ROW);
 

--- a/tests/fixtures/xml/nfse-v2.xml
+++ b/tests/fixtures/xml/nfse-v2.xml
@@ -7,6 +7,7 @@
         <xLocEmi>Curitiba</xLocEmi>
         <ambGer>1</ambGer>
         <emit>
+            <xNome>Prestador Nacional de Servicos Ltda</xNome>
             <enderNac>
                 <UF>PR</UF>
             </enderNac>
@@ -24,7 +25,6 @@
                     <CNPJ>12345678000195</CNPJ>
                     <IM>12345</IM>
                     <fone>4133334444</fone>
-                    <xNome>Prestador Nacional de Servicos Ltda</xNome>
                     <end>
                         <endNac>
                             <cMun>4106902</cMun>


### PR DESCRIPTION
O campo `xNome` do `prest` não deve ser preenchido quando o Emitente da
DPS for o próprio Prestador, fazendo com que o nome ficasse vazio na
DANFSe.

Mensagem de erro ao tentar informar `xNome` no `prest` na emissão da DPS quando o Prestador é o Emitente:
"Codigo":"E0121",
"Descricao":"O nome ou razão social do prestador não deve ser informado
quando o emitente da DPS for o próprio prestador.