### PR TITLE
Corrige formatacao para telefones (códigos não-geográficos)

### DIFF
--- a/src/NFSe/Danfse.php
+++ b/src/NFSe/Danfse.php
@@ -1009,7 +1009,23 @@ class Danfse extends DaCommon
             return $this->formatField($digits, '(##) ####-####');
         }
         if (strlen($digits) === 11) {
-            return $this->formatField($digits, '(##) #####-####');
+            if (
+                in_array(
+                    substr($digits, 0, 4),
+                    [
+                        '0300',
+                        '0303',
+                        '0304',
+                        '0500',
+                        '0800',
+                        '0900'
+                    ]
+                )
+            ) {
+                return $this->formatField($digits, '#### ### ####');
+            } else {
+                return $this->formatField($digits, '(##) #####-####');
+            }
         }
         return $phone;
     }


### PR DESCRIPTION
Corrige formatação para número como 0800, 0300, 0500 e etc.

https://www.gov.br/anatel/pt-br/regulado/numeracao/codigos-nacionais/codigos-nao-geograficos