### PR TITLE
Fix NFSe cStat labels and watermark handling

### DIFF
--- a/src/NFSe/Danfse.php
+++ b/src/NFSe/Danfse.php
@@ -609,11 +609,10 @@ class Danfse extends DaCommon
 
     private function drawWatermark()
     {
-        $cStat = $this->value('cStat', $this->infNFSe);
-        if ($this->canceled || in_array($cStat, ['101', '135'], true)) {
+        if ($this->canceled) {
             $this->watermark('CANCELADA');
         }
-        if ($this->substituted || in_array($cStat, ['102', '151'], true)) {
+        if ($this->substituted) {
             $this->watermark('SUBSTITUÍDA');
         }
     }
@@ -1125,7 +1124,15 @@ class Danfse extends DaCommon
 
     private function situacao($value)
     {
-        $map = ['100' => 'NFS-e autorizada', '101' => 'NFS-e cancelada', '102' => 'NFS-e substituída'];
+        $map = [
+            '100' => 'NFS-e Gerada',
+            '101' => 'NFS-e de Substituição Gerada',
+            '102' => 'NFS-e de Decisão Judicial',
+            '103' => 'NFS-e Avulsa',
+            '107' => 'NFS-e MEI',
+            '108' => 'Nota de Crédito',
+            '109' => 'Nota de Débito',
+        ];
         return isset($map[$value]) ? $map[$value] : $this->dash($value);
     }
 

--- a/tests/NFSe/DanfseTest.php
+++ b/tests/NFSe/DanfseTest.php
@@ -210,10 +210,11 @@ class DanfseTest extends TestCase
         $this->assertStringContainsString('NFS-e SEM VALIDADE JURÍDICA', $text);
         $this->assertStringContainsString('O DESTINATÁRIO É O PRÓPRIO TOMADOR/ADQUIRENTE DA OPERAÇÃO', $text);
         $this->assertStringContainsString('NFS-e Subst.: 99999999999999999999999999999999999999999999999999', $text);
-        $this->assertStringContainsString('SUBSTITUÍDA', $text);
+        $this->assertStringContainsString('NFS-e de Decisão Judicial', $text);
+        $this->assertStringNotContainsString('SUBSTITUÍDA', $text);
     }
 
-    public function testImprimeMarcaDaguaCanceladaQuandoXmlIndicaCancelamento(): void
+    public function testNaoImprimeMarcaDaguaCanceladaParaCStat101(): void
     {
         $xml = str_replace(
             '<cStat>100</cStat>',
@@ -225,12 +226,12 @@ class DanfseTest extends TestCase
         $text = $this->textFromPdf($pdf);
         $operators = $this->decompressedPdfOperators($pdf);
 
-        $this->assertStringContainsString('CANCELADA', $text);
-        $this->assertStringContainsString('0.651 0.651 0.651 rg', $operators);
-        $this->assertGreaterThan(50.0, $this->watermarkFontSize($operators, 'CANCELADA'));
+        $this->assertStringContainsString('NFS-e de Substituição Gerada', $text);
+        $this->assertStringNotContainsString('CANCELADA', $text);
+        $this->assertEquals(0.0, $this->watermarkFontSize($operators, 'CANCELADA'));
     }
 
-    public function testImprimeMarcaDaguaSubstituidaQuandoXmlIndicaSubstituicao(): void
+    public function testNaoImprimeMarcaDaguaSubstituidaParaCStat102(): void
     {
         $xml = str_replace(
             '<cStat>100</cStat>',
@@ -247,8 +248,35 @@ class DanfseTest extends TestCase
         $text = $this->textFromPdf($pdf);
         $operators = $this->decompressedPdfOperators($pdf);
 
-        $this->assertStringContainsString('NFS-e substituída', $text);
+        $this->assertStringContainsString('NFS-e de Decisão Judicial', $text);
         $this->assertStringContainsString('NFS-e Subst.: 99999999999999999999999999999999999999999999999999', $text);
+        $this->assertStringNotContainsString('SUBSTITUÍDA', $text);
+        $this->assertEquals(0.0, $this->watermarkFontSize($operators, 'SUBSTITUÍDA'));
+    }
+
+    public function testImprimeMarcaDaguaCanceladaQuandoMarcadaManualmente(): void
+    {
+        $danfse = new Danfse(file_get_contents(TEST_FIXTURES . 'xml/nfse-v2.xml'));
+        $danfse->setAsCanceled();
+
+        $pdf = $danfse->render();
+        $text = $this->textFromPdf($pdf);
+        $operators = $this->decompressedPdfOperators($pdf);
+
+        $this->assertStringContainsString('CANCELADA', $text);
+        $this->assertStringContainsString('0.651 0.651 0.651 rg', $operators);
+        $this->assertGreaterThan(50.0, $this->watermarkFontSize($operators, 'CANCELADA'));
+    }
+
+    public function testImprimeMarcaDaguaSubstituidaQuandoMarcadaManualmente(): void
+    {
+        $danfse = new Danfse(file_get_contents(TEST_FIXTURES . 'xml/nfse-v2.xml'));
+        $danfse->setAsSubstituted();
+
+        $pdf = $danfse->render();
+        $text = $this->textFromPdf($pdf);
+        $operators = $this->decompressedPdfOperators($pdf);
+
         $this->assertStringContainsString('SUBSTITUÍDA', $text);
         $this->assertStringContainsString('0.651 0.651 0.651 rg', $operators);
         $this->assertGreaterThan(50.0, $this->watermarkFontSize($operators, 'SUBSTITUÍDA'));


### PR DESCRIPTION
Corrige Danfse::situacao() para a tabela oficial da NFS-e Nacional:
100 = NFS-e Gerada
101 = NFS-e de Substituição Gerada
102 = NFS-e de Decisão Judicial
Adiciona 103, 107, 108, 109
Remove a inferência automática de tarja CANCELADA/SUBSTITUÍDA por cStat.
Mantém setAsCanceled() e setAsSubstituted() funcionando.
Atualiza/adiciona testes.

Evidência oficial: planilha do gov.br, aba Leiaute DPS_NFS-e - RT, linha 18, campo NFSe/infNFSe/cStat:
https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica/rtc/anexovi-leiautesrn_rtc_ibscbs-v1-00-01.xlsx